### PR TITLE
YAML/JSON configuration of multiple bridges to run in a single golang process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ethconnect-go-win
 ethconnect-go-tux
 ethconnect-go-mac
 coverage.txt
+**/debug.test

--- a/cmd/ethconnect.go
+++ b/cmd/ethconnect.go
@@ -91,15 +91,9 @@ func initServer() (serverCmd *cobra.Command) {
 }
 
 func readServerConfig() (serverConfig *ServerConfig, err error) {
-	yamlFile, err := os.Open(serverCmdConfig.Filename)
+	yamlBytes, err := ioutil.ReadFile(serverCmdConfig.Filename)
 	if err != nil {
-		err = fmt.Errorf("Failed to open %s: %s", serverCmdConfig.Filename, err)
-		return
-	}
-	yamlBytes, err := ioutil.ReadAll(yamlFile)
-	yamlFile.Close()
-	if err != nil {
-		err = fmt.Errorf("Failed to read contents of %s: %s", serverCmdConfig.Filename, err)
+		err = fmt.Errorf("Failed to read %s: %s", serverCmdConfig.Filename, err)
 		return
 	}
 	serverConfig = &ServerConfig{}

--- a/cmd/ethconnect.go
+++ b/cmd/ethconnect.go
@@ -119,13 +119,13 @@ func startServer() (err error) {
 			return err
 		}
 		wg.Add(1)
-		go func() {
+		go func(name string) {
 			log.Infof("Starting Kafka->Ethereum bridge '%s'", name)
 			if err := kafkaBridge.Start(); err != nil {
 				log.Errorf("Kafka->Ethereum bridge failed: %s", err)
 			}
 			wg.Done()
-		}()
+		}(name)
 	}
 	for name, conf := range serverConfig.WebhooksBridges {
 		webhooksBridge := kldwebhooks.NewWebhooksBridge()
@@ -134,13 +134,13 @@ func startServer() (err error) {
 			return err
 		}
 		wg.Add(1)
-		go func() {
+		go func(name string) {
 			log.Infof("Starting Webhooks->Kafka bridge '%s'", name)
 			if err := webhooksBridge.Start(); err != nil {
 				log.Errorf("Webhooks->Kafka bridge failed: %s", err)
 			}
 			wg.Done()
-		}()
+		}(name)
 	}
 	wg.Wait()
 

--- a/cmd/ethconnect_test.go
+++ b/cmd/ethconnect_test.go
@@ -135,3 +135,27 @@ func TestExecuteServerWithYAML(t *testing.T) {
 
 	assert.Equal(0, osExit)
 }
+
+func TestExecuteServerWithJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	exampleConfYAML, _ := ioutil.TempFile("", "testJSON")
+	defer syscall.Unlink(exampleConfYAML.Name())
+	testJSON := "{ \"kafka\": {\n" +
+		"  \"kbridge1\": {\n" +
+		"    \"topicIn\": \"in1\",\n" +
+		"    \"topicOut\": \"out1\",\n" +
+		"    \"rpc\": {\n" +
+		"      \"url\": \"http://ethereum1\"\n" +
+		"      }\n" +
+		"    }\n" +
+		"  }\n" +
+		"}\n"
+	ioutil.WriteFile(exampleConfYAML.Name(), []byte(testJSON), 0644)
+
+	log.Infof("JSON: %s", testJSON)
+	rootCmd.SetArgs([]string{"server", "-t", "json", "-f", exampleConfYAML.Name()})
+	osExit := Execute()
+
+	assert.Equal(0, osExit)
+}

--- a/internal/kldkafka/kafkabridge.go
+++ b/internal/kldkafka/kafkabridge.go
@@ -32,12 +32,12 @@ import (
 
 // KafkaBridgeConf defines the YAML config structure for a webhooks bridge instance
 type KafkaBridgeConf struct {
-	Kafka         KafkaCommonConf `yaml:"kafka"`
-	MaxInFlight   int             `yaml:"maxInFlight"`
-	MaxTXWaitTime int             `yaml:"maxTXWaitTime"`
+	Kafka         KafkaCommonConf `json:"kafka"`
+	MaxInFlight   int             `json:"maxInFlight"`
+	MaxTXWaitTime int             `json:"maxTXWaitTime"`
 	RPC           struct {
-		URL string `yaml:"url"`
-	} `yaml:"rpc"`
+		URL string `json:"url"`
+	} `json:"rpc"`
 }
 
 // KafkaBridge receives messages from Kafka and dispatches them to go-ethereum over JSON/RPC
@@ -306,7 +306,7 @@ func NewKafkaBridge() *KafkaBridge {
 		inFlight:     make(map[string]*msgContext),
 		inFlightCond: sync.NewCond(&sync.Mutex{}),
 	}
-	k.kafka = NewKafkaCommon(&SaramaKafkaFactory{}, k)
+	k.kafka = NewKafkaCommon(&SaramaKafkaFactory{}, &k.conf.Kafka, k)
 	return k
 }
 

--- a/internal/kldkafka/kafkabridge.go
+++ b/internal/kldkafka/kafkabridge.go
@@ -30,15 +30,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// KafkaBridgeConf defines the YAML config structure for a webhooks bridge instance
+type KafkaBridgeConf struct {
+	Kafka         KafkaCommonConf `yaml:"kafka"`
+	MaxInFlight   int             `yaml:"maxInFlight"`
+	MaxTXWaitTime int             `yaml:"maxTXWaitTime"`
+	RPC           struct {
+		URL string `yaml:"url"`
+	} `yaml:"rpc"`
+}
+
 // KafkaBridge receives messages from Kafka and dispatches them to go-ethereum over JSON/RPC
 type KafkaBridge struct {
-	Conf struct {
-		MaxInFlight   int
-		MaxTXWaitTime int
-		RPC           struct {
-			URL string
-		}
-	}
+	Conf         KafkaBridgeConf
 	kafka        KafkaCommon
 	rpc          *rpc.Client
 	processor    MsgProcessor

--- a/internal/kldkafka/kafkabridge.go
+++ b/internal/kldkafka/kafkabridge.go
@@ -66,7 +66,13 @@ func (k *KafkaBridge) ValidateConf() (err error) {
 		return fmt.Errorf("No JSON/RPC URL set for ethereum node")
 	}
 	if k.conf.MaxTXWaitTime < 10 {
-		return fmt.Errorf("tx-timeout must be at least 10s")
+		if k.conf.MaxTXWaitTime > 0 {
+			log.Warnf("Maximum wait time increased from %d to minimum of 10 seconds", k.conf.MaxTXWaitTime)
+		}
+		k.conf.MaxTXWaitTime = 10
+	}
+	if k.conf.MaxInFlight == 0 {
+		k.conf.MaxInFlight = 10
 	}
 	return
 }
@@ -90,9 +96,9 @@ func (k *KafkaBridge) CobraInit() (cmd *cobra.Command) {
 		},
 	}
 	k.kafka.CobraInit(cmd)
-	cmd.Flags().IntVarP(&k.conf.MaxInFlight, "maxinflight", "m", kldutils.DefInt("KAFKA_MAX_INFLIGHT", 10), "Maximum messages to hold in-flight")
+	cmd.Flags().IntVarP(&k.conf.MaxInFlight, "maxinflight", "m", kldutils.DefInt("KAFKA_MAX_INFLIGHT", 0), "Maximum messages to hold in-flight")
 	cmd.Flags().StringVarP(&k.conf.RPC.URL, "rpc-url", "r", os.Getenv("ETH_RPC_URL"), "JSON/RPC URL for Ethereum node")
-	cmd.Flags().IntVarP(&k.conf.MaxTXWaitTime, "tx-timeout", "x", kldutils.DefInt("ETH_TX_TIMEOUT", 300), "Maximum wait time for an individual transaction (seconds)")
+	cmd.Flags().IntVarP(&k.conf.MaxTXWaitTime, "tx-timeout", "x", kldutils.DefInt("ETH_TX_TIMEOUT", 0), "Maximum wait time for an individual transaction (seconds)")
 	return
 }
 

--- a/internal/kldkafka/kafkabridge_test.go
+++ b/internal/kldkafka/kafkabridge_test.go
@@ -110,7 +110,7 @@ func newTestKafkaBridge() (k *KafkaBridge, kafkaCmd *cobra.Command) {
 func TestExecuteBridgeWithIncompleteArgs(t *testing.T) {
 	assert := assert.New(t)
 
-	_, kafkaCmd := newTestKafkaBridge()
+	k, kafkaCmd := newTestKafkaBridge()
 	testArgs := []string{}
 
 	kafkaCmd.SetArgs(testArgs)
@@ -121,7 +121,8 @@ func TestExecuteBridgeWithIncompleteArgs(t *testing.T) {
 	testArgs = append(testArgs, []string{"--tx-timeout", "1"}...)
 	kafkaCmd.SetArgs(testArgs)
 	err = kafkaCmd.Execute()
-	assert.Equal("tx-timeout must be at least 10s", err.Error())
+	// Bumped up to minimum
+	assert.Equal(10, k.conf.MaxTXWaitTime)
 }
 
 func TestExecuteBridgeWithIncompleteKafkaArgs(t *testing.T) {
@@ -178,6 +179,7 @@ func TestExecuteWithBadRPCURL(t *testing.T) {
 
 func setupMocks() (*KafkaBridge, *testKafkaMsgProcessor, *MockKafkaConsumer, *MockKafkaProducer, *sync.WaitGroup) {
 	k, _ := newTestKafkaBridge()
+	k.conf.MaxInFlight = 10
 	f := NewMockKafkaFactory()
 	mockConsumer, _ := f.NewConsumer(k.kafka)
 	mockProducer, _ := f.NewProducer(k.kafka)

--- a/internal/kldkafka/kafkabridge_test.go
+++ b/internal/kldkafka/kafkabridge_test.go
@@ -35,10 +35,10 @@ var kbMinWorkingArgs = []string{
 }
 
 type testKafkaCommon struct {
-	startCalled        bool
-	startErr           error
-	cobraInitCalled    bool
-	cobraPreRunECalled bool
+	startCalled     bool
+	startErr        error
+	validateErr     error
+	cobraInitCalled bool
 }
 
 func (k *testKafkaCommon) Start() error {
@@ -50,9 +50,8 @@ func (k *testKafkaCommon) CobraInit(cmd *cobra.Command) {
 	k.cobraInitCalled = true
 }
 
-func (k *testKafkaCommon) CobraPreRunE(cmd *cobra.Command) error {
-	k.cobraPreRunECalled = true
-	return nil
+func (k *testKafkaCommon) ValidateConf() error {
+	return k.validateErr
 }
 
 func (k *testKafkaCommon) CreateTLSConfiguration() (t *tls.Config, err error) {
@@ -61,6 +60,10 @@ func (k *testKafkaCommon) CreateTLSConfiguration() (t *tls.Config, err error) {
 
 func (k *testKafkaCommon) Conf() *KafkaCommonConf {
 	return &KafkaCommonConf{}
+}
+
+func (k *testKafkaCommon) SetConf(*KafkaCommonConf) {
+	return
 }
 
 func (k *testKafkaCommon) Producer() KafkaProducer {
@@ -85,6 +88,10 @@ func TestNewKafkaBridge(t *testing.T) {
 	assert := assert.New(t)
 
 	bridge := NewKafkaBridge()
+	var conf KafkaBridgeConf
+	conf.RPC.URL = "http://example.com"
+	bridge.SetConf(&conf)
+	assert.Equal("http://example.com", bridge.Conf().RPC.URL)
 
 	assert.NotNil(bridge.inFlight)
 	assert.NotNil(bridge.inFlightCond)
@@ -117,6 +124,18 @@ func TestExecuteBridgeWithIncompleteArgs(t *testing.T) {
 	assert.Equal("tx-timeout must be at least 10s", err.Error())
 }
 
+func TestExecuteBridgeWithIncompleteKafkaArgs(t *testing.T) {
+	assert := assert.New(t)
+
+	k, kafkaCmd := newTestKafkaBridge()
+	k.kafka.(*testKafkaCommon).validateErr = fmt.Errorf("pop")
+	testArgs := []string{}
+
+	kafkaCmd.SetArgs(testArgs)
+	err := kafkaCmd.Execute()
+	assert.Equal(err.Error(), "pop")
+}
+
 func TestDefIntWithBadEnvVar(t *testing.T) {
 	assert := assert.New(t)
 
@@ -128,7 +147,7 @@ func TestDefIntWithBadEnvVar(t *testing.T) {
 	err := kafkaCmd.Execute()
 
 	assert.Nil(err)
-	assert.Equal(10, k.Conf.MaxInFlight)
+	assert.Equal(10, k.conf.MaxInFlight)
 }
 
 func TestDefIntWithGoodEnvVar(t *testing.T) {
@@ -142,7 +161,7 @@ func TestDefIntWithGoodEnvVar(t *testing.T) {
 	err := kafkaCmd.Execute()
 
 	assert.Nil(err)
-	assert.Equal(123, k.Conf.MaxInFlight)
+	assert.Equal(123, k.conf.MaxInFlight)
 }
 
 func TestExecuteWithBadRPCURL(t *testing.T) {
@@ -284,7 +303,7 @@ func TestMoreMessagesThanMaxInFlight(t *testing.T) {
 	assert := assert.New(t)
 
 	k, processor, mockConsumer, mockProducer, wg := setupMocks()
-	assert.Equal(10, k.Conf.MaxInFlight)
+	assert.Equal(10, k.conf.MaxInFlight)
 
 	// Send 20 messages (10 is the max inflight)
 	go func() {
@@ -389,7 +408,7 @@ func TestAddInflightMessageBadMessage(t *testing.T) {
 func TestProducerErrorLoopPanics(t *testing.T) {
 	assert := assert.New(t)
 
-	k, _, _, mockProducer, _ := setupMocks()
+	k, _, _, mockProducer, wg := setupMocks()
 
 	go func() {
 		mockProducer.MockErrors <- &sarama.ProducerError{
@@ -398,7 +417,6 @@ func TestProducerErrorLoopPanics(t *testing.T) {
 		}
 	}()
 
-	wg := &sync.WaitGroup{}
 	assert.Panics(func() {
 		k.ProducerErrorLoop(nil, mockProducer, wg)
 	})
@@ -408,7 +426,7 @@ func TestProducerErrorLoopPanics(t *testing.T) {
 func TestProducerSuccessLoopPanicsMsgNotInflight(t *testing.T) {
 	assert := assert.New(t)
 
-	k, _, _, mockProducer, _ := setupMocks()
+	k, _, _, mockProducer, wg := setupMocks()
 
 	go func() {
 		mockProducer.MockSuccesses <- &sarama.ProducerMessage{
@@ -416,9 +434,8 @@ func TestProducerSuccessLoopPanicsMsgNotInflight(t *testing.T) {
 		}
 	}()
 
-	wg := sync.WaitGroup{}
 	assert.Panics(func() {
-		k.ProducerSuccessLoop(nil, mockProducer, &wg)
+		k.ProducerSuccessLoop(nil, mockProducer, wg)
 	})
 
 }

--- a/internal/kldkafka/kafkacommon.go
+++ b/internal/kldkafka/kafkacommon.go
@@ -48,7 +48,7 @@ type KafkaCommonConf struct {
 
 // KafkaCommon is the base interface for bridges that interact with Kafka
 type KafkaCommon interface {
-	CobraPreRunE(cmd *cobra.Command) error
+	ValidateConf() error
 	CobraInit(cmd *cobra.Command)
 	Start() error
 	Conf() *KafkaCommonConf
@@ -88,8 +88,8 @@ func (k *kafkaCommon) Producer() KafkaProducer {
 	return k.producer
 }
 
-// CobraPreRunE performs common Cobra PreRunE logic for Kafka related commands
-func (k *kafkaCommon) CobraPreRunE(cmd *cobra.Command) (err error) {
+// ValidateConf performs common Cobra PreRunE logic for Kafka related commands
+func (k *kafkaCommon) ValidateConf() (err error) {
 	if k.conf.TopicOut == "" {
 		return fmt.Errorf("No output topic specified for bridge to send events to")
 	}
@@ -99,10 +99,8 @@ func (k *kafkaCommon) CobraPreRunE(cmd *cobra.Command) (err error) {
 	if k.conf.ConsumerGroup == "" {
 		return fmt.Errorf("No consumer group specified")
 	}
-	if err = kldutils.AllOrNoneReqd(cmd, "tls-clientcerts", "tls-clientkey"); err != nil {
-		return
-	}
-	if err = kldutils.AllOrNoneReqd(cmd, "sasl-username", "sasl-password"); err != nil {
+	if !kldutils.AllOrNoneReqd(k.conf.SASL.Username, k.conf.SASL.Password) {
+		err = fmt.Errorf("Username and Password must both be provided for SASL")
 		return
 	}
 	return

--- a/internal/kldkafka/kafkacommon.go
+++ b/internal/kldkafka/kafkacommon.go
@@ -34,16 +34,16 @@ import (
 
 // KafkaCommonConf - Common configuration for Kafka
 type KafkaCommonConf struct {
-	Brokers       []string `yaml:"brokers"`
-	ClientID      string   `yaml:"clientID"`
-	ConsumerGroup string   `yaml:"consumerGroup"`
-	TopicIn       string   `yaml:"topicIn"`
-	TopicOut      string   `yaml:"topicOut"`
+	Brokers       []string `json:"brokers"`
+	ClientID      string   `json:"clientID"`
+	ConsumerGroup string   `json:"consumerGroup"`
+	TopicIn       string   `json:"topicIn"`
+	TopicOut      string   `json:"topicOut"`
 	SASL          struct {
 		Username string
 		Password string
-	} `yaml:"sasl"`
-	TLS kldutils.TLSConfig `yaml:"tls"`
+	} `json:"sasl"`
+	TLS kldutils.TLSConfig `json:"tls"`
 }
 
 // KafkaCommon is the base interface for bridges that interact with Kafka
@@ -56,10 +56,11 @@ type KafkaCommon interface {
 }
 
 // NewKafkaCommon constructs a new KafkaCommon instance
-func NewKafkaCommon(kf KafkaFactory, kafkaGoRoutines KafkaGoRoutines) (k KafkaCommon) {
+func NewKafkaCommon(kf KafkaFactory, conf *KafkaCommonConf, kafkaGoRoutines KafkaGoRoutines) (k KafkaCommon) {
 	k = &kafkaCommon{
 		factory:         kf,
 		kafkaGoRoutines: kafkaGoRoutines,
+		conf:            conf,
 	}
 	return
 }
@@ -67,7 +68,7 @@ func NewKafkaCommon(kf KafkaFactory, kafkaGoRoutines KafkaGoRoutines) (k KafkaCo
 // *kafkaCommon provides a base command for establishing Kafka connectivity with a
 // producer and a consumer-group
 type kafkaCommon struct {
-	conf            KafkaCommonConf
+	conf            *KafkaCommonConf
 	factory         KafkaFactory
 	rpc             *rpc.Client
 	client          KafkaClient
@@ -81,7 +82,7 @@ type kafkaCommon struct {
 }
 
 func (k *kafkaCommon) Conf() *KafkaCommonConf {
-	return &k.conf
+	return k.conf
 }
 
 func (k *kafkaCommon) Producer() KafkaProducer {

--- a/internal/kldkafka/kafkacommon_test.go
+++ b/internal/kldkafka/kafkacommon_test.go
@@ -66,7 +66,7 @@ var kcMinWorkingArgs = []string{
 func newTestKafkaCommon(testArgs []string) (*kafkaCommon, *cobra.Command) {
 	log.SetLevel(log.DebugLevel)
 	gr := &testKafkaGoRoutines{}
-	k := NewKafkaCommon(NewMockKafkaFactory(), gr).(*kafkaCommon)
+	k := NewKafkaCommon(NewMockKafkaFactory(), &KafkaCommonConf{}, gr).(*kafkaCommon)
 
 	kafkaCmd := &cobra.Command{
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -111,7 +111,7 @@ func execKafkaCommonWithArgs(assert *assert.Assertions, testArgs []string, f *Mo
 func TestNewKafkaCommon(t *testing.T) {
 	assert := assert.New(t)
 	gr := &testKafkaGoRoutines{}
-	k := NewKafkaCommon(NewMockKafkaFactory(), gr)
+	k := NewKafkaCommon(NewMockKafkaFactory(), &KafkaCommonConf{}, gr)
 	assert.NotNil(k.Conf())
 }
 

--- a/internal/kldkafka/kafkacommon_test.go
+++ b/internal/kldkafka/kafkacommon_test.go
@@ -67,12 +67,13 @@ func newTestKafkaCommon(testArgs []string) (*kafkaCommon, *cobra.Command) {
 	log.SetLevel(log.DebugLevel)
 	gr := &testKafkaGoRoutines{}
 	k := NewKafkaCommon(NewMockKafkaFactory(), gr).(*kafkaCommon)
+
 	kafkaCmd := &cobra.Command{
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return k.Start()
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
-			err = k.CobraPreRunE(cmd)
+			err = k.ValidateConf()
 			return
 		},
 	}
@@ -108,8 +109,10 @@ func execKafkaCommonWithArgs(assert *assert.Assertions, testArgs []string, f *Mo
 }
 
 func TestNewKafkaCommon(t *testing.T) {
+	assert := assert.New(t)
 	gr := &testKafkaGoRoutines{}
-	NewKafkaCommon(NewMockKafkaFactory(), gr)
+	k := NewKafkaCommon(NewMockKafkaFactory(), gr)
+	assert.NotNil(k.Conf())
 }
 
 func TestExecuteWithIncompleteArgs(t *testing.T) {
@@ -131,12 +134,12 @@ func TestExecuteWithIncompleteArgs(t *testing.T) {
 
 	testArgs = append(testArgs, []string{"--tls-clientcerts", "/some/file"}...)
 	_, err = execKafkaCommonWithArgs(assert, testArgs, f)
-	assert.Equal("flag mismatch: 'tls-clientcerts' set and 'tls-clientkey' unset", err.Error())
+	assert.Equal("Client private key and certificate must both be provided for mutual auth", err.Error())
 	testArgs = append(testArgs, []string{"--tls-clientkey", "somekey"}...)
 
 	testArgs = append(testArgs, []string{"--sasl-username", "testuser"}...)
 	_, err = execKafkaCommonWithArgs(assert, testArgs, f)
-	assert.Equal("flag mismatch: 'sasl-username' set and 'sasl-password' unset", err.Error())
+	assert.Equal("Username and Password must both be provided for SASL", err.Error())
 	testArgs = append(testArgs, []string{"--sasl-password", "testpass"}...)
 
 }
@@ -176,7 +179,8 @@ func TestExecuteWithNoTLS(t *testing.T) {
 	assert := assert.New(t)
 
 	f := NewMockKafkaFactory()
-	_, err := execKafkaCommonWithArgs(assert, kcMinWorkingArgs, f)
+	k, err := execKafkaCommonWithArgs(assert, kcMinWorkingArgs, f)
+	assert.NotNil(k.Producer())
 
 	assert.Equal(nil, err)
 	assert.Equal(true, f.ClientConf.Producer.Return.Successes)

--- a/internal/kldutils/cmdutils.go
+++ b/internal/kldutils/cmdutils.go
@@ -15,32 +15,23 @@
 package kldutils
 
 import (
-	"fmt"
 	"os"
 	"strconv"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
-// AllOrNoneReqd util for checking Cobra parameters in PreRunE validators
-func AllOrNoneReqd(cmd *cobra.Command, opts ...string) (err error) {
+// AllOrNoneReqd util for checking parameters that must be provided together
+func AllOrNoneReqd(opts ...string) (ok bool) {
 	var setFlags, unsetFlags []string
 	for _, opt := range opts {
-		if optVal, err := cmd.Flags().GetString(opt); err == nil {
-			if optVal != "" {
-				setFlags = append(setFlags, opt)
-			} else {
-				unsetFlags = append(unsetFlags, opt)
-			}
+		if opt != "" {
+			setFlags = append(setFlags, opt)
 		} else {
-			return err
+			unsetFlags = append(unsetFlags, opt)
 		}
 	}
-	if len(setFlags) != 0 && len(unsetFlags) != 0 {
-		return fmt.Errorf("flag mismatch: '%s' set and '%s' unset", strings.Join(setFlags, ","), strings.Join(unsetFlags, ","))
-	}
+	ok = !(len(setFlags) != 0 && len(unsetFlags) != 0)
 	return
 }
 

--- a/internal/kldutils/cmdutils_test.go
+++ b/internal/kldutils/cmdutils_test.go
@@ -1,0 +1,73 @@
+// Copyright 2018 Kaleido, a ConsenSys business
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kldutils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllOrNoneReqd(t *testing.T) {
+
+	assert := assert.New(t)
+
+	cmd := &cobra.Command{
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			return
+		},
+	}
+	cmd.Flags().String("flag1", "", "Flag 1")
+	cmd.Flags().String("flag2", "", "Flag 2")
+
+	err := AllOrNoneReqd(cmd, "flag1", "flag2")
+	assert.Nil(err)
+
+	cmd.Flags().Set("flag1", "value1")
+
+	err = AllOrNoneReqd(cmd, "flag1", "flag2")
+	assert.Regexp("flag mismatch", err.Error())
+
+	cmd.Flags().Set("flag2", "value2")
+
+	err = AllOrNoneReqd(cmd, "flag1", "flag2")
+	assert.Nil(err)
+
+	err = AllOrNoneReqd(cmd, "random")
+	assert.Regexp("flag accessed but not defined", err.Error())
+
+}
+
+func TestDefInt(t *testing.T) {
+
+	assert := assert.New(t)
+
+	os.Unsetenv("SOME_ENV_VAR")
+
+	val := DefInt("SOME_ENV_VAR", 12345)
+	assert.Equal(12345, val)
+
+	os.Setenv("SOME_ENV_VAR", "not a number!")
+
+	val = DefInt("SOME_ENV_VAR", 12345)
+	assert.Equal(12345, val)
+
+	os.Setenv("SOME_ENV_VAR", "54321")
+	val = DefInt("SOME_ENV_VAR", 12345)
+	assert.Equal(54321, val)
+
+}

--- a/internal/kldutils/cmdutils_test.go
+++ b/internal/kldutils/cmdutils_test.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,29 +25,10 @@ func TestAllOrNoneReqd(t *testing.T) {
 
 	assert := assert.New(t)
 
-	cmd := &cobra.Command{
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			return
-		},
-	}
-	cmd.Flags().String("flag1", "", "Flag 1")
-	cmd.Flags().String("flag2", "", "Flag 2")
-
-	err := AllOrNoneReqd(cmd, "flag1", "flag2")
-	assert.Nil(err)
-
-	cmd.Flags().Set("flag1", "value1")
-
-	err = AllOrNoneReqd(cmd, "flag1", "flag2")
-	assert.Regexp("flag mismatch", err.Error())
-
-	cmd.Flags().Set("flag2", "value2")
-
-	err = AllOrNoneReqd(cmd, "flag1", "flag2")
-	assert.Nil(err)
-
-	err = AllOrNoneReqd(cmd, "random")
-	assert.Regexp("flag accessed but not defined", err.Error())
+	assert.Equal(true, AllOrNoneReqd("", ""))
+	assert.Equal(false, AllOrNoneReqd("flag1", ""))
+	assert.Equal(false, AllOrNoneReqd("", "flag2"))
+	assert.Equal(true, AllOrNoneReqd("flag1", "flag2"))
 
 }
 

--- a/internal/kldutils/ethutils_test.go
+++ b/internal/kldutils/ethutils_test.go
@@ -1,0 +1,41 @@
+// Copyright 2018 Kaleido, a ConsenSys business
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kldutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStrToAddress(t *testing.T) {
+
+	assert := assert.New(t)
+
+	_, err := StrToAddress("missing", "")
+	assert.Regexp("must be supplied", err.Error())
+
+	_, err = StrToAddress("will not parse", "badness")
+	assert.Regexp("is not a valid hex address", err.Error())
+
+	addr, err := StrToAddress("good one with hex prefix", "0xd15aD5D4a0853585d655B30819C16bAAed412FFf")
+	assert.Nil(err)
+	assert.Equal("0xd15aD5D4a0853585d655B30819C16bAAed412FFf", addr.Hex())
+
+	addr, err = StrToAddress("good one without prefix", "d15aD5D4a0853585d655B30819C16bAAed412FFf")
+	assert.Nil(err)
+	assert.Equal("0xd15aD5D4a0853585d655B30819C16bAAed412FFf", addr.Hex())
+
+}

--- a/internal/kldutils/tlsutils.go
+++ b/internal/kldutils/tlsutils.go
@@ -17,6 +17,7 @@ package kldutils
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io/ioutil"
 
 	log "github.com/sirupsen/logrus"
@@ -33,6 +34,11 @@ type TLSConfig struct {
 
 // CreateTLSConfiguration creates a tls.Config structure based on parsing the configuration passed in via a TLSConfig structure
 func CreateTLSConfiguration(tlsConfig *TLSConfig) (t *tls.Config, err error) {
+
+	if !AllOrNoneReqd(tlsConfig.ClientCertsFile, tlsConfig.ClientKeyFile) {
+		err = fmt.Errorf("Client private key and certificate must both be provided for mutual auth")
+		return
+	}
 
 	mutualAuth := tlsConfig.ClientCertsFile != "" && tlsConfig.ClientKeyFile != ""
 	log.Debugf("Kafka TLS Enabled=%t Insecure=%t MutualAuth=%t ClientCertsFile=%s PrivateKeyFile=%s CACertsFile=%s",

--- a/internal/kldutils/tlsutils.go
+++ b/internal/kldutils/tlsutils.go
@@ -25,11 +25,11 @@ import (
 
 // TLSConfig is the common TLS config
 type TLSConfig struct {
-	ClientCertsFile    string `yaml:"clientCertsFile"`
-	ClientKeyFile      string `yaml:"clientKeyFile"`
-	CACertsFile        string `yaml:"caCertsFile"`
-	Enabled            bool   `yaml:"enabled"`
-	InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+	ClientCertsFile    string `json:"clientCertsFile"`
+	ClientKeyFile      string `json:"clientKeyFile"`
+	CACertsFile        string `json:"caCertsFile"`
+	Enabled            bool   `json:"enabled"`
+	InsecureSkipVerify bool   `json:"insecureSkipVerify"`
 }
 
 // CreateTLSConfiguration creates a tls.Config structure based on parsing the configuration passed in via a TLSConfig structure

--- a/internal/kldutils/tlsutils.go
+++ b/internal/kldutils/tlsutils.go
@@ -1,0 +1,71 @@
+// Copyright 2018 Kaleido, a ConsenSys business
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kldutils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// TLSConfig is the common TLS config
+type TLSConfig struct {
+	ClientCertsFile    string `yaml:"clientCertsFile"`
+	ClientKeyFile      string `yaml:"clientKeyFile"`
+	CACertsFile        string `yaml:"caCertsFile"`
+	Enabled            bool   `yaml:"enabled"`
+	InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+}
+
+// CreateTLSConfiguration creates a tls.Config structure based on parsing the configuration passed in via a TLSConfig structure
+func CreateTLSConfiguration(tlsConfig *TLSConfig) (t *tls.Config, err error) {
+
+	mutualAuth := tlsConfig.ClientCertsFile != "" && tlsConfig.ClientKeyFile != ""
+	log.Debugf("Kafka TLS Enabled=%t Insecure=%t MutualAuth=%t ClientCertsFile=%s PrivateKeyFile=%s CACertsFile=%s",
+		tlsConfig.Enabled, tlsConfig.InsecureSkipVerify, mutualAuth, tlsConfig.ClientCertsFile, tlsConfig.ClientKeyFile, tlsConfig.CACertsFile)
+	if !tlsConfig.Enabled {
+		return
+	}
+
+	var clientCerts []tls.Certificate
+	if mutualAuth {
+		var cert tls.Certificate
+		if cert, err = tls.LoadX509KeyPair(tlsConfig.ClientCertsFile, tlsConfig.ClientKeyFile); err != nil {
+			log.Errorf("Unable to load client key/certificate: %s", err)
+			return
+		}
+		clientCerts = append(clientCerts, cert)
+	}
+
+	var caCertPool *x509.CertPool
+	if tlsConfig.CACertsFile != "" {
+		var caCert []byte
+		if caCert, err = ioutil.ReadFile(tlsConfig.CACertsFile); err != nil {
+			log.Errorf("Unable to load CA certificates: %s", err)
+			return
+		}
+		caCertPool = x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+	}
+
+	t = &tls.Config{
+		Certificates:       clientCerts,
+		RootCAs:            caCertPool,
+		InsecureSkipVerify: tlsConfig.InsecureSkipVerify,
+	}
+	return
+}

--- a/internal/kldutils/tlsutils_test.go
+++ b/internal/kldutils/tlsutils_test.go
@@ -1,0 +1,126 @@
+// Copyright 2018 Kaleido, a ConsenSys business
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kldutils
+
+import (
+	"io/ioutil"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestCreateTLSConfigurationWithDefaultOptions(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	assert := assert.New(t)
+
+	tlsConfigOptions := TLSConfig{}
+	tlsConfig, err := CreateTLSConfiguration(&tlsConfigOptions)
+
+	assert.Nil(err)
+	assert.Nil(tlsConfig)
+
+}
+
+func TestCreateTLSConfigurationWithSelfSignedMutualAuth(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	assert := assert.New(t)
+
+	testPrivKeyFile, _ := ioutil.TempFile("", "testprivkey")
+	defer syscall.Unlink(testPrivKeyFile.Name())
+	ioutil.WriteFile(testPrivKeyFile.Name(), []byte(
+		"-----BEGIN PRIVATE KEY-----\n"+
+			"MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDXCA6IdwIgFeRw\n"+
+			"MSEJSbKWtujq4+8DUEZIYRLbYXq2oblrK6ObmtkdBOUktDGeVbeaffEHJsqN5pYE\n"+
+			"n9WBMdxxYkQtov5DX8Gbmx8IUr74NtosCG2jWW5yVjdMYhf8IGPUQsV6Za5L2VBX\n"+
+			"o4kd6wA25AKYz+xao0WFxHiqDTJteWGvl+e44IinrQ2yTfcB43PjYUcqav4VO1dt\n"+
+			"VrDSMcVs6vtXLzX4sFewqudrACirJOgtZs5kfLYQO5coTN35mUIeY8eRUtWapq8e\n"+
+			"bhtTbO4gxOyfwJ3Ck2A3mk6TcZYLT/g+6X8FxohGzymbBYTr7HXb6f/GC1DQu0hg\n"+
+			"SP98+y1pAgMBAAECggEAQY1wOMPm/vcNk/I2Owmfivip2umvtJflRS1qvTxjV4fH\n"+
+			"6db84nP7WjBi1qSkN7uz5EIel2qI92djNnevc9pKdLpbRHpa/xkTAafxdu0a0LqQ\n"+
+			"Gjpbih+6XtrPstZ4r2EEbfIJF74lu3O9XWo6Y8d/YjxyWjmQuTTq/dOeYWDyjZKT\n"+
+			"WgpaneD2vxRAwvUCaypvGNs20FjX7MhgB7Xj2MDg3t04C10s/G7IGyncuZfrnZU9\n"+
+			"LA70aZEaW/TkbWyzEMr4ObjjkIO0Xlr1pp1fNIGIFc39tzQoKDhLP/0t4MFXrgm8\n"+
+			"/ff+sW7pNd2sbZHaUPTzBYEa/D4XcLVqt/479F4SHQKBgQDsEzVBFyWCBJ2UiCYw\n"+
+			"jmMS8jURi9k5DuwSUOPGkJgRI0U6uyXh6s8u9UHPbgKhMf9IUs2fMaGG338tDRyP\n"+
+			"SDT5x84jCoIKjj9CXKHbsfmHW6EzHJqXgYX3rnv19cwpJ2a1Wryoljca+zecwpUX\n"+
+			"CNXTm3oRGj6aim8VYRcyaQfEdwKBgQDpLir0iNoq3CuGJFqTYydFQuSWIs8DszXm\n"+
+			"12k4kFe0+6ANM2yxM0JkvPljLz/Pfb+1mDKK5dqBlILZ/T3100hpvzEueJoeoT2q\n"+
+			"a7rF9+6iOF62DNfyis0DxFmB8KYf4GUaWnGI7z0UVZaFdjhvl/xATMMcaSFZVA+m\n"+
+			"cNm42cB1HwKBgDGwMUtL9ecR1aEHrxIVRiEcvbK9vrDVxTZttCN9F6SzycR805Jj\n"+
+			"e8wkbv+b5g3LmjG8y+6v4ZGjxP7UfahiyFOyjF6vvYM/QW1UVfUJ1r14ucsqQBeX\n"+
+			"eX0SSqEQZTJcSq/tMzxAscSKD8B87Ch3AZqSZPTokziv3oWfc+R2Wt4tAoGBAILa\n"+
+			"Np69QXi1zvLa6b018i6q6C3cYMFZyxC8pz5nueBFKD7gMcmK02JGrchcFnnwvilA\n"+
+			"vHQ3opP+7CM6Oo/9vfAhq47BfPNdVoaRJ+G6TT7ZVUTiFjj0bTIE+JmzmvXebb4J\n"+
+			"LRdD8cm8cdh5TBhLePH4YbFKyb0gMBwdzgAuqhLPAoGBAMuMa5gEGNvUMRA5hymp\n"+
+			"IKMoO01vmc7c8gJmunFujMZS1fQQA2Qzw16z6ekZgLVgLz27ivfh203qgqORWyXg\n"+
+			"HvrK9nTzXLEnYprg0bmyivjo0LAk0ISuAdTSWGWhUZqLON8g5T9AmCGmtFE6FZEl\n"+
+			"YV406bLxh5diFcQIEFGfgWNe\n"+
+			"-----END PRIVATE KEY-----\n"), 0644)
+
+	testCertData := []byte(
+		"-----BEGIN CERTIFICATE-----\n" +
+			"MIIDYjCCAkoCCQCl+tdkvcUkzTANBgkqhkiG9w0BAQsFADBzMQswCQYDVQQGEwJV\n" +
+			"UzELMAkGA1UECAwCTkMxEDAOBgNVBAcMB1JhbGVpZ2gxEDAOBgNVBAoMB0thbGVp\n" +
+			"ZG8xFTATBgNVBAsMDFVuaXQgdGVzdGluZzEcMBoGA1UEAwwTdW5pdHRlc3RAa2Fs\n" +
+			"ZWlkby5pbzAeFw0xODA2MjUxOTAzMzJaFw0xODA3MjUxOTAzMzJaMHMxCzAJBgNV\n" +
+			"BAYTAlVTMQswCQYDVQQIDAJOQzEQMA4GA1UEBwwHUmFsZWlnaDEQMA4GA1UECgwH\n" +
+			"S2FsZWlkbzEVMBMGA1UECwwMVW5pdCB0ZXN0aW5nMRwwGgYDVQQDDBN1bml0dGVz\n" +
+			"dEBrYWxlaWRvLmlvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1wgO\n" +
+			"iHcCIBXkcDEhCUmylrbo6uPvA1BGSGES22F6tqG5ayujm5rZHQTlJLQxnlW3mn3x\n" +
+			"BybKjeaWBJ/VgTHccWJELaL+Q1/Bm5sfCFK++DbaLAhto1luclY3TGIX/CBj1ELF\n" +
+			"emWuS9lQV6OJHesANuQCmM/sWqNFhcR4qg0ybXlhr5fnuOCIp60Nsk33AeNz42FH\n" +
+			"Kmr+FTtXbVaw0jHFbOr7Vy81+LBXsKrnawAoqyToLWbOZHy2EDuXKEzd+ZlCHmPH\n" +
+			"kVLVmqavHm4bU2zuIMTsn8CdwpNgN5pOk3GWC0/4Pul/BcaIRs8pmwWE6+x12+n/\n" +
+			"xgtQ0LtIYEj/fPstaQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQDSVZLxNLrsuciQ\n" +
+			"NIxbaBhjpilrOvGheKNZH6cSscPhfqyLSLrx1BumgB8Bp2aCxTv9zDh4ugUhrkEz\n" +
+			"babAZJAlIfSD3IdwVFR4O2FBOLn73Ql1xoTqN1S2tersLzRy87BfDWxNIMQzwK5U\n" +
+			"3I+xwCPCbtBrxZPULXT+fBlZjwCgC0MdKgq3aMsPLlPawSk1sT8BvQrn3o7dSe8q\n" +
+			"kAhSssaP9XJDoV6saPMzjb+WUNZgI3uTw3nxbjr+rIM+C2KvPGS/+lpFfpGg0DMf\n" +
+			"+eHpZMb2Vf1HzDxM1KGkpDI2McyVF6OxHJcITPY2GG2FKMnxg5Zj3Euzs8FDcg62\n" +
+			"IjUBP/mt\n" +
+			"-----END CERTIFICATE-----\n")
+	testCertFile, _ := ioutil.TempFile("", "testcert")
+	defer syscall.Unlink(testCertFile.Name())
+	ioutil.WriteFile(testCertFile.Name(), testCertData, 0644)
+	testCACertFile, _ := ioutil.TempFile("", "testca")
+	defer syscall.Unlink(testCACertFile.Name())
+	ioutil.WriteFile(testCACertFile.Name(), testCertData, 0644)
+
+	tlsConfigOptions := TLSConfig{
+		Enabled:            true,
+		InsecureSkipVerify: true,
+		ClientKeyFile:      testPrivKeyFile.Name(),
+		ClientCertsFile:    testCertFile.Name(),
+		CACertsFile:        testCACertFile.Name(),
+	}
+	tlsConfig, err := CreateTLSConfiguration(&tlsConfigOptions)
+
+	assert.Equal(nil, err)
+	assert.Equal(1, len(tlsConfig.Certificates))
+	assert.Equal(1, len(tlsConfig.RootCAs.Subjects()))
+	assert.Equal(true, tlsConfig.InsecureSkipVerify)
+
+	// Validate error handling
+	syscall.Unlink(testCACertFile.Name())
+	tlsConfig, err = CreateTLSConfiguration(&tlsConfigOptions)
+	assert.Regexp("no such file or directory", err.Error())
+
+	syscall.Unlink(testCertFile.Name())
+	tlsConfig, err = CreateTLSConfiguration(&tlsConfigOptions)
+	assert.Regexp("no such file or directory", err.Error())
+}

--- a/internal/kldutils/tlsutils_test.go
+++ b/internal/kldutils/tlsutils_test.go
@@ -36,6 +36,17 @@ func TestCreateTLSConfigurationWithDefaultOptions(t *testing.T) {
 
 }
 
+func TestCreateTLSConfigurationWithInvalMutalAuth(t *testing.T) {
+	assert := assert.New(t)
+
+	tlsConfigOptions := TLSConfig{
+		ClientCertsFile: "anything",
+	}
+	_, err := CreateTLSConfiguration(&tlsConfigOptions)
+
+	assert.Regexp("Client private key and certificate must both be provided for mutual auth", err.Error())
+}
+
 func TestCreateTLSConfigurationWithSelfSignedMutualAuth(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	assert := assert.New(t)

--- a/internal/kldutils/uuidutils_test.go
+++ b/internal/kldutils/uuidutils_test.go
@@ -15,11 +15,15 @@
 package kldutils
 
 import (
-	uuid "github.com/nu7hatch/gouuid"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-// UUIDv4 returns a new UUID V4 as a string
-func UUIDv4() string {
-	uuidV4, _ := uuid.NewV4()
-	return uuidV4.String()
+func TestUUIDv4(t *testing.T) {
+	assert := assert.New(t)
+
+	uuidV4 := UUIDv4()
+	assert.Regexp("[0-9a-f-]+", uuidV4)
+
 }

--- a/internal/kldwebhooks/webhooksbridge.go
+++ b/internal/kldwebhooks/webhooksbridge.go
@@ -46,12 +46,12 @@ const (
 
 // WebhooksBridgeConf defines the YAML config structure for a webhooks bridge instance
 type WebhooksBridgeConf struct {
-	Kafka kldkafka.KafkaCommonConf `yaml:"kafka"`
+	Kafka kldkafka.KafkaCommonConf `json:"kafka"`
 	HTTP  struct {
-		LocalAddr string             `yaml:"localAddr"`
-		Port      int                `yaml:"port"`
-		TLS       kldutils.TLSConfig `yaml:"tls"`
-	} `yaml:"http"`
+		LocalAddr string             `json:"localAddr"`
+		Port      int                `json:"port"`
+		TLS       kldutils.TLSConfig `json:"tls"`
+	} `json:"http"`
 }
 
 // WebhooksBridge receives messages over HTTP POST and sends them to Kafka
@@ -90,7 +90,7 @@ func NewWebhooksBridge() (w *WebhooksBridge) {
 		failedMsgs:  make(map[string]error),
 	}
 	kf := &kldkafka.SaramaKafkaFactory{}
-	w.kafka = kldkafka.NewKafkaCommon(kf, w)
+	w.kafka = kldkafka.NewKafkaCommon(kf, &w.conf.Kafka, w)
 	return
 }
 

--- a/internal/kldwebhooks/webhooksbridge.go
+++ b/internal/kldwebhooks/webhooksbridge.go
@@ -65,6 +65,22 @@ type WebhooksBridge struct {
 	failedMsgs  map[string]error
 }
 
+// Conf gets the config for this bridge
+func (w *WebhooksBridge) Conf() *WebhooksBridgeConf {
+	return &w.conf
+}
+
+// SetConf sets the config for this bridge
+func (w *WebhooksBridge) SetConf(conf *WebhooksBridgeConf) {
+	w.conf = *conf
+}
+
+// ValidateConf validates the config
+func (w *WebhooksBridge) ValidateConf() (err error) {
+	// No validation currently
+	return
+}
+
 // NewWebhooksBridge constructor
 func NewWebhooksBridge() (w *WebhooksBridge) {
 	w = &WebhooksBridge{
@@ -82,19 +98,22 @@ func NewWebhooksBridge() (w *WebhooksBridge) {
 func (w *WebhooksBridge) CobraInit() (cmd *cobra.Command) {
 	cmd = &cobra.Command{
 		Use:   "webhooks",
-		Short: "Webhooks bridge to Kafka",
+		Short: "Webhooks->Kafka Bridge",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			err = w.Start()
 			return
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
-			if err = w.kafka.CobraPreRunE(cmd); err != nil {
+			if err = w.kafka.ValidateConf(); err != nil {
 				return
 			}
+
 			// The simple commandline interface requires the TLS configuration for
 			// both Kafka and HTTP is the same. Only the YAML configuration allows
 			// them to be different
 			w.conf.HTTP.TLS = w.kafka.Conf().TLS
+
+			err = w.ValidateConf()
 			return
 		},
 	}

--- a/internal/kldwebhooks/webhooksbridge_test.go
+++ b/internal/kldwebhooks/webhooksbridge_test.go
@@ -116,7 +116,7 @@ func startTestWebhooks(testArgs []string, kafka *testKafkaCommon) (*WebhooksBrid
 	status := -1
 	var err error
 	for (err == nil || err.Error() == "none") && status != 200 {
-		statusURL := fmt.Sprintf("http://localhost:%d/status", w.conf.Port)
+		statusURL := fmt.Sprintf("http://localhost:%d/status", w.conf.HTTP.Port)
 		resp, httpErr := http.Get(statusURL)
 		if httpErr == nil {
 			status = resp.StatusCode
@@ -143,8 +143,8 @@ func TestStartStopDefaultArgs(t *testing.T) {
 	w, err := startTestWebhooks([]string{}, k)
 	assert.Nil(err)
 
-	assert.Equal(8080, w.conf.Port)    // default
-	assert.Equal("", w.conf.LocalAddr) // default
+	assert.Equal(8080, w.conf.HTTP.Port)    // default
+	assert.Equal("", w.conf.HTTP.LocalAddr) // default
 
 	k.stop <- true
 }
@@ -156,8 +156,8 @@ func TestStartStopCustomArgs(t *testing.T) {
 	w, err := startTestWebhooks([]string{"-l", "8081", "-L", "127.0.0.1"}, k)
 	assert.Nil(err)
 
-	assert.Equal(8081, w.conf.Port)
-	assert.Equal("127.0.0.1", w.conf.LocalAddr)
+	assert.Equal(8081, w.conf.HTTP.Port)
+	assert.Equal("127.0.0.1", w.conf.HTTP.LocalAddr)
 	assert.Equal("127.0.0.1:8081", w.srv.Addr)
 
 	k.stop <- true
@@ -291,9 +291,9 @@ func sendTestTransaction(assert *assert.Assertions, msgBytes []byte, contentType
 
 	var url string
 	if ack {
-		url = fmt.Sprintf("http://localhost:%d/hook", w.conf.Port)
+		url = fmt.Sprintf("http://localhost:%d/hook", w.conf.HTTP.Port)
 	} else {
-		url = fmt.Sprintf("http://localhost:%d/fasthook", w.conf.Port)
+		url = fmt.Sprintf("http://localhost:%d/fasthook", w.conf.HTTP.Port)
 
 	}
 	resp, httpErr := http.Post(url, contentType, bytes.NewReader(msgBytes))


### PR DESCRIPTION
Allows the service to be run with YAML configuration such as:

```sh
./ethconnect server -f config.yaml -d 3
```

```yaml
kafka:
  kafka1:
    kafka:
      brokers:
        - broker1:9092
        - broker2:9092
      topicIn: topicA
      topicOut: topicB
      sasl:
        username: user1
        password: pass1
      tls:
        enabled: true
      consumerGroup: group1
    rpc:
      url: https://ethnode.example.com
webhooks:
  webhooks1:
    http:
      port: 8001
    kafka:
      brokers:
        - broker1:9092
        - broker2:9092
      topicOut: topicA
      topicIn: topicB
      sasl:
        username: user1
        password: pass1
      tls:
        enabled: true
      consumerGroup: group2

```