### PR TITLE
Propagate the Webhooks request ID into the Kafka message headers

### DIFF
--- a/internal/kldwebhooks/replyprocessor.go
+++ b/internal/kldwebhooks/replyprocessor.go
@@ -193,6 +193,9 @@ func (w *WebhooksBridge) processReply(msgBytes []byte) {
 func (w *WebhooksBridge) ConsumerMessagesLoop(consumer kldkafka.KafkaConsumer, producer kldkafka.KafkaProducer, wg *sync.WaitGroup) {
 	for msg := range consumer.Messages() {
 		w.processReply(msg.Value)
+
+		// Regardless of outcome, we ack
+		consumer.MarkOffset(msg, "")
 	}
 	wg.Done()
 }

--- a/internal/kldwebhooks/webhooksbridge_test.go
+++ b/internal/kldwebhooks/webhooksbridge_test.go
@@ -557,28 +557,3 @@ func TestWebhookHandlerTooBig(t *testing.T) {
 	assertErrResp(assert, resp, 400, "Message exceeds maximum allowable size")
 	assert.Equal(0, len(replyMsgs))
 }
-
-func TestConsumerMessagesLoopCallsReplyProcessorWithEmptyPayload(t *testing.T) {
-	assert := assert.New(t)
-
-	k := newTestKafkaComon()
-	w, err := startTestWebhooks(nil, k)
-	assert.Nil(err)
-
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	consumer, _ := k.kafkaFactory.NewConsumer(k)
-	producer, _ := k.kafkaFactory.NewProducer(k)
-
-	go func() {
-		w.ConsumerMessagesLoop(consumer, producer, wg)
-	}()
-
-	consumer.(*kldkafka.MockKafkaConsumer).MockMessages <- &sarama.ConsumerMessage{
-		Value: []byte(""),
-	}
-
-	k.stop <- true
-	wg.Wait()
-
-}

--- a/internal/kldwebhooks/webhooksbridge_test.go
+++ b/internal/kldwebhooks/webhooksbridge_test.go
@@ -271,7 +271,6 @@ func sendTestTransaction(assert *assert.Assertions, msgBytes []byte, contentType
 	go func() {
 		for msg := range k.kafkaFactory.Producer.MockInput {
 			msgBytes, _ := msg.Value.Encode()
-			log.Infof("Message sent by webhook bridge: %s", string(msgBytes))
 			msgs = append(msgs, msgBytes)
 
 			// Send an ack or an err
@@ -326,6 +325,7 @@ func TestWebhookHandlerJSONSendTransaction(t *testing.T) {
 	forwardedMessage := kldmessages.SendTransaction{}
 	json.Unmarshal(replyMsgs[0], &forwardedMessage)
 	assert.Equal(kldmessages.MsgTypeSendTransaction, forwardedMessage.Headers.MsgType)
+	assert.NotEmpty(forwardedMessage.Headers.ID)
 }
 
 func TestWebhookHandlerJSONSendTransactionNoAck(t *testing.T) {


### PR DESCRIPTION
We're need to propagate the ID generated in the Webhooks layer to the message, by re-serializing the parsed JSON/YAML payload as JSON in all cases (not just when converted from YAML).