### PR TITLE
Provide a simpler JSON payload for sending txns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ deps:
 		$(GOGET) github.com/Shopify/sarama
 		$(GOGET) github.com/nu7hatch/gouuid
 		$(GOGET) github.com/stretchr/testify/assert
-		$(GOGET) github.com/golang/mock/gomock
 		$(GOGET) github.com/icza/dyno
 		$(GOGET) gopkg.in/yaml.v2
 		$(GOGET) github.com/globalsign/mgo

--- a/internal/kldeth/txn.go
+++ b/internal/kldeth/txn.go
@@ -70,7 +70,7 @@ func NewContractDeployTxn(msg *kldmessages.DeployContract) (pTX *Txn, err error)
 	}
 
 	// Build correctly typed args for the ethereum call
-	typedArgs, err := pTX.generateTypedArgs(msg.Parameters, compiledSolidity.ABI.Constructor)
+	typedArgs, err := pTX.generateTypedArgs(msg.Parameters, &compiledSolidity.ABI.Constructor)
 	if err != nil {
 		return
 	}
@@ -107,7 +107,7 @@ func NewSendTxn(msg *kldmessages.SendTransaction) (pTX *Txn, err error) {
 	}
 
 	// Build correctly typed args for the ethereum call
-	typedArgs, err := pTX.generateTypedArgs(msg.Parameters, *methodABI)
+	typedArgs, err := pTX.generateTypedArgs(msg.Parameters, methodABI)
 	if err != nil {
 		return
 	}
@@ -315,8 +315,58 @@ func processIntVal(typedArgs []interface{}, methodName string, idx int, required
 	return
 }
 
+// flattenParams flattens an array of parameters of the form
+// [{"value":"val1","type":"uint256"},{"value":"val2","type":"uint256"}]
+// into ["val1","val2"], and updates the abi.Method declaration with any
+// types specified.
+// If a flat structure is passed in, then there are no changes.
+// A mix is tollerated by the code, but no usecase is known for that.
+func (tx *Txn) flattenParams(origParams []interface{}, method *abi.Method) (params []interface{}, err error) {
+	// Allows us to support
+	params = make([]interface{}, len(origParams))
+	for i, unflattened := range origParams {
+		if reflect.TypeOf(unflattened).Kind() != reflect.Map {
+			// No change needed
+			params[i] = unflattened
+		} else {
+			// We need to flatten
+			mapParam := unflattened.(map[string]interface{}) // safe case as we came in from JSON only
+			var value, typeStr interface{}
+			var exists bool
+			if value, exists = mapParam["value"]; exists {
+				typeStr, exists = mapParam["type"]
+			}
+			if !exists {
+				err = fmt.Errorf("Param %d: supplied as an object must have 'type' and 'value' fields", i)
+				return
+			}
+			if reflect.TypeOf(typeStr).Kind() != reflect.String {
+				err = fmt.Errorf("Param %d: supplied as an object must be string", i)
+				return
+			}
+			params[i] = value
+			// Set the type
+			var ethType abi.Type
+			if ethType, err = abi.NewType(typeStr.(string)); err != nil {
+				err = fmt.Errorf("Param %d: Unable to map %s to etherueum type: %s", i, typeStr, err)
+				return
+			}
+			for len(method.Inputs) <= i {
+				method.Inputs = append(method.Inputs, abi.Argument{})
+			}
+			method.Inputs[i].Type = ethType
+		}
+	}
+	return
+}
+
 // GenerateTypedArgs parses string arguments into a range of types to pass to the ABI call
-func (tx *Txn) generateTypedArgs(params []interface{}, method abi.Method) (typedArgs []interface{}, err error) {
+func (tx *Txn) generateTypedArgs(origParams []interface{}, method *abi.Method) (typedArgs []interface{}, err error) {
+
+	params, err := tx.flattenParams(origParams, method)
+	if err != nil {
+		return
+	}
 
 	methodName := method.Name
 	if methodName == "" {

--- a/internal/kldeth/txn.go
+++ b/internal/kldeth/txn.go
@@ -97,13 +97,21 @@ func NewSendTxn(msg *kldmessages.SendTransaction) (pTX *Txn, err error) {
 	var tx Txn
 	pTX = &tx
 
+	var methodABI *abi.Method
 	if msg.Method.Name == "" {
-		err = fmt.Errorf("Method name must be supplied in 'method.name'")
-		return
-	}
-	methodABI, err := genMethodABI(&msg.Method)
-	if err != nil {
-		return
+		if msg.MethodName != "" {
+			methodABI = &abi.Method{
+				Name: msg.MethodName,
+			}
+		} else {
+			err = fmt.Errorf("Method missing - must provide inline 'param' type/value pairs with a 'methodName', or an ABI in 'method'")
+			return
+		}
+	} else {
+		methodABI, err = genMethodABI(&msg.Method)
+		if err != nil {
+			return
+		}
 	}
 
 	// Build correctly typed args for the ethereum call

--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -409,9 +409,7 @@ func TestSendTxnInlineParam(t *testing.T) {
 	param4["type"] = "address"
 	param4["value"] = "0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c"
 
-	msg.Method = kldmessages.ABIMethod{
-		Name: "testFunc",
-	}
+	msg.MethodName = "testFunc"
 	msg.To = "0x2b8c0ECc76d0759a8F50b2E14A6881367D805832"
 	msg.From = "0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c"
 	msg.Nonce = "123"
@@ -554,7 +552,7 @@ func TestSendTxnBadInputType(t *testing.T) {
 	assert.Regexp("ABI input 0: Unable to map param1 to etherueum type: unsupported arg type:", err.Error())
 }
 
-func TestSendTxnMissingMethodName(t *testing.T) {
+func TestSendTxnMissingMethod(t *testing.T) {
 	assert := assert.New(t)
 
 	var msg kldmessages.SendTransaction
@@ -567,7 +565,7 @@ func TestSendTxnMissingMethodName(t *testing.T) {
 	msg.Gas = "456"
 	msg.GasPrice = "789"
 	_, err := NewSendTxn(&msg)
-	assert.Regexp("Method name must be supplied in 'method.name'", err.Error())
+	assert.Regexp("Method missing", err.Error())
 }
 func TestSendTxnBadFrom(t *testing.T) {
 	assert := assert.New(t)

--- a/internal/kldmessages/messages.go
+++ b/internal/kldmessages/messages.go
@@ -105,8 +105,9 @@ type transactionCommon struct {
 // SendTransaction message instructs the bridge to install a contract
 type SendTransaction struct {
 	transactionCommon
-	To     string    `json:"to"`
-	Method ABIMethod `json:"method"`
+	To         string    `json:"to"`
+	Method     ABIMethod `json:"method"`
+	MethodName string    `json:"methodName,omitempty"`
 }
 
 // DeployContract message instructs the bridge to install a contract


### PR DESCRIPTION
Currently we require the method ABI to be sent separately to the parameters:
```yaml
headers:
  type: SendTransaction
from: 0xb480F96c0a3d6E9e9a263e4665a39bFa6c4d01E8
to: 0xe1a078b9e2b145d0a7387f09277c6ae1d9470771
params:
  - 4276993775
gas: 1000000
method:
  name: set
  inputs:
    - name: 'x'
      type: uint256
```

This is overly complicated for the general case. So this PR _also_ provides the ability to in-line the parameter types:
```yaml
headers:
  type: SendTransaction
from: 0xb480F96c0a3d6E9e9a263e4665a39bFa6c4d01E8
to: 0xe1a078b9e2b145d0a7387f09277c6ae1d9470771
methodName: set
params:
  - type: uint256
    value: 4276993775
gas: 1000000
```