### PR TITLE
Fallback to YAML if JSON parsing fails

### DIFF
--- a/internal/kldwebhooks/webhooksbridge_test.go
+++ b/internal/kldwebhooks/webhooksbridge_test.go
@@ -538,7 +538,7 @@ func TestWebhookHandlerBadYAML(t *testing.T) {
 	assert := assert.New(t)
 
 	resp, replyMsgs := sendTestTransaction(assert, []byte("!badness!"), "application/x-yaml", nil, true)
-	assertErrResp(assert, resp, 400, "Unable to parse YAML")
+	assertErrResp(assert, resp, 400, "Unable to parse as YAML or JSON")
 	assert.Equal(0, len(replyMsgs))
 }
 
@@ -547,7 +547,7 @@ func TestWebhookHandlerBadJSON(t *testing.T) {
 	assert := assert.New(t)
 
 	resp, replyMsgs := sendTestTransaction(assert, []byte("badness"), "application/json", nil, true)
-	assertErrResp(assert, resp, 400, "Unable to parse JSON")
+	assertErrResp(assert, resp, 400, "Unable to parse as YAML or JSON")
 	assert.Equal(0, len(replyMsgs))
 }
 


### PR DESCRIPTION
To make it really easy for humans to submit YAML in a CURL or Postman request, then we don't want them to have to specify `Content-type: application/x-yaml`.
This PR means that we try to parse as JSON by default (as we do today), but if that fails we try going through YAML first.