### PR TITLE
Use 'pending' when asking the node for transaction count to account f…

### DIFF
--- a/internal/kldkafka/msgprocessor.go
+++ b/internal/kldkafka/msgprocessor.go
@@ -164,7 +164,9 @@ func (p *msgProcessor) newInflightWrapper(msgContext MsgContext, suppliedFrom st
 	// which will be ok as long as we're the only JSON/RPC writing to
 	// this address. But if we're competing with other transactions
 	// we need to accept the possibility of 'nonce too low'
-	inflight.nonce, err = kldeth.GetTransactionCount(p.rpc, &from, "latest")
+	// use 'pending' here instead of 'latest' to take into account the
+	// transactions that are still pending in the txpool
+	inflight.nonce, err = kldeth.GetTransactionCount(p.rpc, &from, "pending")
 	return
 }
 


### PR DESCRIPTION
…or pending tx in the txpool

Otherwise we may see "replacement transaction underpriced" error when transactions are submitted
in quick succession from the same account