### PR TITLE
Default to letting the Node assign the nonce for node-signed txns

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Flags:
   -g, --consumer-group string    Client ID (or generated UUID)
   -h, --help                     help for kafka
   -m, --maxinflight int          Maximum messages to hold in-flight
-  -P, --predict-nonces           Predict the next nonce before sending txns (default=false for mode-signed txns)
+  -P, --predict-nonces           Predict the next nonce before sending txns (default=false for node-signed txns)
   -r, --rpc-url string           JSON/RPC URL for Ethereum node
   -p, --sasl-password string     Password for SASL authentication
   -u, --sasl-username string     Username for SASL authentication

--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Flags:
   -g, --consumer-group string    Client ID (or generated UUID)
   -h, --help                     help for kafka
   -m, --maxinflight int          Maximum messages to hold in-flight
+  -P, --predict-nonces           Predict the next nonce before sending txns (default=false for mode-signed txns)
   -r, --rpc-url string           JSON/RPC URL for Ethereum node
   -p, --sasl-password string     Password for SASL authentication
   -u, --sasl-username string     Username for SASL authentication

--- a/internal/kldeth/send.go
+++ b/internal/kldeth/send.go
@@ -45,13 +45,13 @@ func (tx *Txn) Send(rpc RPCClient) error {
 }
 
 type sendTxArgs struct {
-	Nonce    hexutil.Uint64 `json:"nonce"`
-	From     string         `json:"from"`
-	To       string         `json:"to,omitempty"`
-	Gas      hexutil.Uint64 `json:"gas"`
-	GasPrice hexutil.Big    `json:"gasPrice"`
-	Value    hexutil.Big    `json:"value"`
-	Data     *hexutil.Bytes `json:"data"`
+	Nonce    *hexutil.Uint64 `json:"nonce,omitempty"`
+	From     string          `json:"from"`
+	To       string          `json:"to,omitempty"`
+	Gas      hexutil.Uint64  `json:"gas"`
+	GasPrice hexutil.Big     `json:"gasPrice"`
+	Value    hexutil.Big     `json:"value"`
+	Data     *hexutil.Bytes  `json:"data"`
 	// EEA spec extensions
 	PrivateFrom string   `json:"privateFrom,omitempty"`
 	PrivateFor  []string `json:"privateFor,omitempty"`
@@ -60,8 +60,13 @@ type sendTxArgs struct {
 // sendUnsignedTxn sends a transaction for internal signing by the node
 func (tx *Txn) sendUnsignedTxn(ctx context.Context, rpc RPCClient) (string, error) {
 	data := hexutil.Bytes(tx.EthTX.Data())
+	var nonce *hexutil.Uint64
+	if !tx.NodeAssignNonce {
+		hexNonce := hexutil.Uint64(tx.EthTX.Nonce())
+		nonce = &hexNonce
+	}
 	args := sendTxArgs{
-		Nonce:    hexutil.Uint64(tx.EthTX.Nonce()),
+		Nonce:    nonce,
 		From:     tx.From.Hex(),
 		Gas:      hexutil.Uint64(tx.EthTX.Gas()),
 		GasPrice: hexutil.Big(*tx.EthTX.GasPrice()),

--- a/internal/kldeth/txn.go
+++ b/internal/kldeth/txn.go
@@ -36,10 +36,11 @@ import (
 // Txn wraps an ethereum transaction, along with the logic to send it over
 // JSON/RPC to a node
 type Txn struct {
-	From    common.Address
-	EthTX   *types.Transaction
-	Hash    string
-	Receipt TxnReceipt
+	NodeAssignNonce bool
+	From            common.Address
+	EthTX           *types.Transaction
+	Hash            string
+	Receipt         TxnReceipt
 }
 
 // TxnReceipt is the receipt obtained over JSON/RPC from the ethereum client
@@ -168,10 +169,13 @@ func (tx *Txn) genEthTransaction(msgFrom, msgTo string, msgNonce, msgValue, msgG
 		return
 	}
 
-	nonce, err := msgNonce.Int64()
-	if err != nil {
-		err = fmt.Errorf("Converting supplied 'nonce' to integer: %s", err)
-		return
+	var nonce int64
+	if msgNonce != "" {
+		nonce, err = msgNonce.Int64()
+		if err != nil {
+			err = fmt.Errorf("Converting supplied 'nonce' to integer: %s", err)
+			return
+		}
 	}
 
 	value := big.NewInt(0)

--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -436,6 +436,58 @@ func TestSendTxnInlineParam(t *testing.T) {
 	assert.Regexp("0xe5537abb000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000007b0000000000000000000000000000000000000000000000000000000000000080000000000000000000000000aa983ad2a0e0ed8ac639277f37be42f2a5d2618c00000000000000000000000000000000000000000000000000000000000000036162630000000000000000000000000000000000000000000000000000000000", jsonSent["data"])
 }
 
+func TestSendTxnNodeAssignNonce(t *testing.T) {
+	assert := assert.New(t)
+
+	var msg kldmessages.SendTransaction
+	msg.Parameters = []interface{}{}
+
+	param1 := make(map[string]interface{})
+	msg.Parameters = append(msg.Parameters, param1)
+	param1["type"] = "uint8"
+	param1["value"] = "123"
+
+	param2 := make(map[string]interface{})
+	msg.Parameters = append(msg.Parameters, param2)
+	param2["type"] = "int256"
+	param2["value"] = float64(123)
+
+	param3 := make(map[string]interface{})
+	msg.Parameters = append(msg.Parameters, param3)
+	param3["type"] = "string"
+	param3["value"] = "abc"
+
+	param4 := make(map[string]interface{})
+	msg.Parameters = append(msg.Parameters, param4)
+	param4["type"] = "address"
+	param4["value"] = "0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c"
+
+	msg.MethodName = "testFunc"
+	msg.To = "0x2b8c0ECc76d0759a8F50b2E14A6881367D805832"
+	msg.From = "0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c"
+	msg.Value = "0"
+	msg.Gas = "456"
+	msg.GasPrice = "789"
+	tx, err := NewSendTxn(&msg)
+	assert.Nil(err)
+	msgBytes, _ := json.Marshal(&msg)
+	log.Infof(string(msgBytes))
+
+	rpc := testRPCClient{}
+
+	tx.NodeAssignNonce = true
+	tx.Send(&rpc)
+	assert.Equal("eth_sendTransaction", rpc.capturedMethod)
+	jsonBytesSent, _ := json.Marshal(rpc.capturedArgs[0])
+	var jsonSent map[string]interface{}
+	json.Unmarshal(jsonBytesSent, &jsonSent)
+	assert.Equal(nil, jsonSent["nonce"])
+	assert.Equal("0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c", jsonSent["from"])
+	assert.Equal("0x1c8", jsonSent["gas"])
+	assert.Equal("0x0", jsonSent["gasPrice"])
+	assert.Equal("0x315", jsonSent["value"])
+	assert.Regexp("0xe5537abb000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000007b0000000000000000000000000000000000000000000000000000000000000080000000000000000000000000aa983ad2a0e0ed8ac639277f37be42f2a5d2618c00000000000000000000000000000000000000000000000000000000000000036162630000000000000000000000000000000000000000000000000000000000", jsonSent["data"])
+}
 func TestSendTxnInlineBadParamType(t *testing.T) {
 	assert := assert.New(t)
 

--- a/internal/kldkafka/kafkabridge.go
+++ b/internal/kldkafka/kafkabridge.go
@@ -32,10 +32,11 @@ import (
 
 // KafkaBridgeConf defines the YAML config structure for a webhooks bridge instance
 type KafkaBridgeConf struct {
-	Kafka         KafkaCommonConf `json:"kafka"`
-	MaxInFlight   int             `json:"maxInFlight"`
-	MaxTXWaitTime int             `json:"maxTXWaitTime"`
-	RPC           struct {
+	Kafka             KafkaCommonConf `json:"kafka"`
+	MaxInFlight       int             `json:"maxInFlight"`
+	MaxTXWaitTime     int             `json:"maxTXWaitTime"`
+	AlwaysManageNonce bool            `json:"alwaysManageNonce"`
+	RPC               struct {
 		URL string `json:"url"`
 	} `json:"rpc"`
 }
@@ -100,6 +101,7 @@ func (k *KafkaBridge) CobraInit() (cmd *cobra.Command) {
 	cmd.Flags().IntVarP(&k.conf.MaxInFlight, "maxinflight", "m", kldutils.DefInt("KAFKA_MAX_INFLIGHT", 0), "Maximum messages to hold in-flight")
 	cmd.Flags().StringVarP(&k.conf.RPC.URL, "rpc-url", "r", os.Getenv("ETH_RPC_URL"), "JSON/RPC URL for Ethereum node")
 	cmd.Flags().IntVarP(&k.conf.MaxTXWaitTime, "tx-timeout", "x", kldutils.DefInt("ETH_TX_TIMEOUT", 0), "Maximum wait time for an individual transaction (seconds)")
+	cmd.Flags().BoolVarP(&k.conf.AlwaysManageNonce, "always-manage-nonce", "U", false, "Always predict the next nonce before sending txns, even when the node is signing")
 	return
 }
 
@@ -315,6 +317,7 @@ func NewKafkaBridge(printYAML *bool) *KafkaBridge {
 		inFlight:     make(map[string]*msgContext),
 		inFlightCond: sync.NewCond(&sync.Mutex{}),
 	}
+	mp.conf = &k.conf // Inherit our configuration in the processor
 	k.kafka = NewKafkaCommon(&SaramaKafkaFactory{}, &k.conf.Kafka, k)
 	return k
 }

--- a/internal/kldkafka/kafkabridge.go
+++ b/internal/kldkafka/kafkabridge.go
@@ -32,11 +32,11 @@ import (
 
 // KafkaBridgeConf defines the YAML config structure for a webhooks bridge instance
 type KafkaBridgeConf struct {
-	Kafka             KafkaCommonConf `json:"kafka"`
-	MaxInFlight       int             `json:"maxInFlight"`
-	MaxTXWaitTime     int             `json:"maxTXWaitTime"`
-	AlwaysManageNonce bool            `json:"alwaysManageNonce"`
-	RPC               struct {
+	Kafka         KafkaCommonConf `json:"kafka"`
+	MaxInFlight   int             `json:"maxInFlight"`
+	MaxTXWaitTime int             `json:"maxTXWaitTime"`
+	PredictNonces bool            `json:"alwaysManageNonce"`
+	RPC           struct {
 		URL string `json:"url"`
 	} `json:"rpc"`
 }
@@ -101,7 +101,7 @@ func (k *KafkaBridge) CobraInit() (cmd *cobra.Command) {
 	cmd.Flags().IntVarP(&k.conf.MaxInFlight, "maxinflight", "m", kldutils.DefInt("KAFKA_MAX_INFLIGHT", 0), "Maximum messages to hold in-flight")
 	cmd.Flags().StringVarP(&k.conf.RPC.URL, "rpc-url", "r", os.Getenv("ETH_RPC_URL"), "JSON/RPC URL for Ethereum node")
 	cmd.Flags().IntVarP(&k.conf.MaxTXWaitTime, "tx-timeout", "x", kldutils.DefInt("ETH_TX_TIMEOUT", 0), "Maximum wait time for an individual transaction (seconds)")
-	cmd.Flags().BoolVarP(&k.conf.AlwaysManageNonce, "always-manage-nonce", "U", false, "Always predict the next nonce before sending txns, even when the node is signing")
+	cmd.Flags().BoolVarP(&k.conf.PredictNonces, "predict-nonces", "P", false, "Predict the next nonce before sending (default=false for node-signed txns)")
 	return
 }
 

--- a/internal/kldkafka/msgprocessor.go
+++ b/internal/kldkafka/msgprocessor.go
@@ -167,7 +167,7 @@ func (p *msgProcessor) newInflightWrapper(msgContext MsgContext, suppliedFrom st
 	// If this is a node-signed transaction, then we can ask the node
 	// to simply use the next available nonce.
 	// We provide an override to force the Go code to always assign the nonce.
-	if !p.conf.AlwaysManageNonce {
+	if !p.conf.PredictNonces {
 		inflight.nodeAssignNonce = true
 	} else {
 		// Alternatively (will be required when we support externally signed tranactions)

--- a/internal/kldkafka/msgprocessor.go
+++ b/internal/kldkafka/msgprocessor.go
@@ -38,11 +38,12 @@ type MsgProcessor interface {
 }
 
 type inflightTxn struct {
-	from       string // normalized to 0x prefix and lower case
-	nonce      int64
-	msgContext MsgContext
-	tx         *kldeth.Txn
-	wg         sync.WaitGroup
+	from            string // normalized to 0x prefix and lower case
+	nodeAssignNonce bool
+	nonce           int64
+	msgContext      MsgContext
+	tx              *kldeth.Txn
+	wg              sync.WaitGroup
 }
 
 func (i *inflightTxn) nonceNumber() json.Number {
@@ -63,6 +64,7 @@ type msgProcessor struct {
 	inflightTxns       map[string][]*inflightTxn
 	inflightTxnDelayer TxnDelayTracker
 	rpc                kldeth.RPCClient
+	conf               *KafkaBridgeConf
 }
 
 func newMsgProcessor() *msgProcessor {
@@ -70,6 +72,7 @@ func newMsgProcessor() *msgProcessor {
 		inflightTxnsLock:   &sync.Mutex{},
 		inflightTxns:       make(map[string][]*inflightTxn),
 		inflightTxnDelayer: NewTxnDelayTracker(),
+		conf:               &KafkaBridgeConf{},
 	}
 }
 
@@ -160,11 +163,22 @@ func (p *msgProcessor) newInflightWrapper(msgContext MsgContext, suppliedFrom st
 		return
 	}
 
-	// Otherwise we need to do a dirty read from the ethereum client,
-	// which will be ok as long as we're the only JSON/RPC writing to
-	// this address. But if we're competing with other transactions
-	// we need to accept the possibility of 'nonce too low'
-	inflight.nonce, err = kldeth.GetTransactionCount(p.rpc, &from, "latest")
+	// We want to submit this transaction with the next nonce in the chain.
+	// If this is a node-signed transaction, then we can ask the node
+	// to simply use the next available nonce.
+	// We provide an override to force the Go code to always assign the nonce.
+	if !p.conf.AlwaysManageNonce {
+		inflight.nodeAssignNonce = true
+	} else {
+		// Alternatively (will be required when we support externally signed tranactions)
+		// we can do a dirty read from the node of the highest comitted
+		// transaction. This will be ok as long as we're the only JSON/RPC writing to
+		// this address. But if we're competing with other transactions
+		// we need to accept the possibility of 'replacement transaction underpriced'
+		// (or if gas price is being varied by the submitter the potential of
+		// overwriting a transcation)
+		inflight.nonce, err = kldeth.GetTransactionCount(p.rpc, &from, "pending")
+	}
 	return
 }
 
@@ -295,6 +309,7 @@ func (p *msgProcessor) OnDeployContractMessage(msgContext MsgContext, msg *kldme
 		msgContext.SendErrorReply(400, err)
 		return
 	}
+	tx.NodeAssignNonce = inflightWrapper.nodeAssignNonce
 
 	if err = tx.Send(p.rpc); err != nil {
 		msgContext.SendErrorReply(400, err)
@@ -318,6 +333,7 @@ func (p *msgProcessor) OnSendTransactionMessage(msgContext MsgContext, msg *kldm
 		msgContext.SendErrorReply(400, err)
 		return
 	}
+	tx.NodeAssignNonce = inflightWrapper.nodeAssignNonce
 
 	if err = tx.Send(p.rpc); err != nil {
 		msgContext.SendErrorReply(400, err)

--- a/internal/kldkafka/msgprocessor_test.go
+++ b/internal/kldkafka/msgprocessor_test.go
@@ -314,7 +314,7 @@ func TestOnDeployContractMessageFailedToGetNonce(t *testing.T) {
 	assert := assert.New(t)
 
 	msgProcessor := newMsgProcessor()
-	msgProcessor.conf.AlwaysManageNonce = true
+	msgProcessor.conf.PredictNonces = true
 	testMsgContext := &testMsgContext{}
 	testMsgContext.jsonMsg = "{" +
 		"  \"headers\":{\"type\": \"DeployContract\"}," +
@@ -448,7 +448,7 @@ func TestOnSendTransactionMessageFailedToGetNonce(t *testing.T) {
 	assert := assert.New(t)
 
 	msgProcessor := newMsgProcessor()
-	msgProcessor.conf.AlwaysManageNonce = true
+	msgProcessor.conf.PredictNonces = true
 	testMsgContext := &testMsgContext{}
 	testMsgContext.jsonMsg = "{" +
 		"  \"headers\":{\"type\": \"SendTransaction\"}," +

--- a/internal/kldkafka/msgprocessor_test.go
+++ b/internal/kldkafka/msgprocessor_test.go
@@ -69,7 +69,6 @@ var goodDeployTxnJSON = "{" +
 var goodSendTxnJSON = "{" +
 	"  \"headers\":{\"type\": \"SendTransaction\"}," +
 	"  \"from\":\"" + testFromAddr + "\"," +
-	"  \"nonce\":\"123\"," +
 	"  \"gas\":\"123\"," +
 	"  \"method\":{\"name\":\"test\"}" +
 	"}"
@@ -315,6 +314,7 @@ func TestOnDeployContractMessageFailedToGetNonce(t *testing.T) {
 	assert := assert.New(t)
 
 	msgProcessor := newMsgProcessor()
+	msgProcessor.conf.AlwaysManageNonce = true
 	testMsgContext := &testMsgContext{}
 	testMsgContext.jsonMsg = "{" +
 		"  \"headers\":{\"type\": \"DeployContract\"}," +
@@ -400,6 +400,7 @@ func TestOnSendTransactionMessageBadJSON(t *testing.T) {
 	assert.Regexp("invalid character", testMsgContext.errorRepies[0].err.Error())
 
 }
+
 func TestOnSendTransactionMessageTxnTimeout(t *testing.T) {
 	assert := assert.New(t)
 
@@ -447,6 +448,7 @@ func TestOnSendTransactionMessageFailedToGetNonce(t *testing.T) {
 	assert := assert.New(t)
 
 	msgProcessor := newMsgProcessor()
+	msgProcessor.conf.AlwaysManageNonce = true
 	testMsgContext := &testMsgContext{}
 	testMsgContext.jsonMsg = "{" +
 		"  \"headers\":{\"type\": \"SendTransaction\"}," +


### PR DESCRIPTION
This PR changes the nonce prediction to be done on the node, rather than in the Go code, by default when submitting node-signed transactions.

This is to resolve #21 where we have seen that the `eth_getTransactionCount` JSON/RPC call is less reliable and then server-side in returning the most up to date nonce. This affects cases where ethconnect is not the only submitter of transactions to a node, and other clients (such as `web2` clients) are using the same accounts in the node wallet for signing.