### PR TITLE
Update tests to support compilers >=0.4.22 <0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,20 +106,20 @@ params:
   - 12345
 gas: 1000000
 solidity: |-
-  pragma solidity ^0.4.17;
-  
+  pragma solidity >=0.4.22 <0.6.0;
+
   contract simplestorage {
      uint public storedData;
-  
+
      function simplestorage(uint initVal) public {
         storedData = initVal;
      }
-  
+
      function set(uint x) public {
         storedData = x;
      }
-  
-     function get() public constant returns (uint retVal) {
+
+     function get() public view returns (uint retVal) {
         return storedData;
      }
   }
@@ -143,7 +143,7 @@ Instead thick client libraries such as [web3.js](https://github.com/ethereum/web
 These thick client libraries perform many of the same functions as kaleido-io/ethconnect, simplifying submission of transactions, receipt checking,
 nonce management etc.
 
-In the modern world of Microservice architectures, having a simple, efficient 
+In the modern world of Microservice architectures, having a simple, efficient
 and stateless REST API to submit transactions is a desirable alternative. A small self-contained, optimized, and independently scalable layer that can exposing a simple API that can be consumed by any application, programming language, or Integration tool.
 
 e.g. making it trivial to submit transactions. No coding required, just open up [Postman](https://www.getpostman.com/) and send in some YAML or JSON copied from a README like this one.
@@ -204,7 +204,7 @@ The management of this `nonce` pushes complexity back to the application tier - 
 The kaleido-io/ethconnect bridge contains all the logic necessary to communicate with the node to determine the next nonce, and also to cope with multiple requests being in flight within the same block, for the same sender (including [with IBFT](https://github.com/ethereum/EIPs/issues/650#issuecomment-360085474)).
 
 When using the bridge, an application can submit simple YAML/JSON formatted transactions
-in a highly parallel way across many instances using the same sender address to the bridge 
+in a highly parallel way across many instances using the same sender address to the bridge
 over HTTPS/Kafka _without_ a nonce. Then through ordered message delivery and nonce management
 code within the kaleido-io/ethconnect bridge it will be assigned a nonce and submitted
 into the Ethereum node. The nonce assigned is returned by the bridge in the reply.
@@ -522,7 +522,7 @@ make it into a block:
 - Transactions that require funding, where the funds are not available (pending transactions)
 - Transactions with explicitly set nonce values, that are not the next to be executed (queued transactions)
 
-When transactions are being submitted from multiple nodes into a chain, it is also possible 
+When transactions are being submitted from multiple nodes into a chain, it is also possible
 for a build-up of transactions to occur such that it can take a significant amount of time
 to get a transaction into a block.
 

--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -40,8 +40,8 @@ func (r *testRPCClient) CallContext(ctx context.Context, result interface{}, met
 }
 
 const (
-	simpleStorage = "pragma solidity ^0.4.17;\n\ncontract simplestorage {\nuint public storedData;\n\nfunction simplestorage(uint initVal) public {\nstoredData = initVal;\n}\n\nfunction set(uint x) public {\nstoredData = x;\n}\n\nfunction get() public constant returns (uint retVal) {\nreturn storedData;\n}\n}"
-	twoContracts  = "pragma solidity ^0.4.17;\n\ncontract contract1 {function f1() public constant returns (uint retVal) {\nreturn 1;\n}\n}\n\ncontract contract2 {function f2() public constant returns (uint retVal) {\nreturn 2;\n}\n}"
+	simpleStorage = "pragma solidity >=0.4.22 <0.6.0;\n\ncontract simplestorage {\nuint public storedData;\n\nconstructor(uint initVal) public {\nstoredData = initVal;\n}\n\nfunction set(uint x) public {\nstoredData = x;\n}\n\nfunction get() public view returns (uint retVal) {\nreturn storedData;\n}\n}"
+	twoContracts  = "pragma solidity >=0.4.22 <0.6.0;\n\ncontract contract1 {function f1() public pure returns (uint retVal) {\nreturn 1;\n}\n}\n\ncontract contract2 {function f2() public pure returns (uint retVal) {\nreturn 2;\n}\n}"
 )
 
 func TestNewContractDeployTxnSimpleStorage(t *testing.T) {
@@ -227,7 +227,7 @@ func testComplexParam(t *testing.T, solidityType string, val interface{}, expect
 	assert := assert.New(t)
 
 	var msg kldmessages.DeployContract
-	msg.Solidity = "pragma solidity ^0.4.17; contract test {constructor(" + solidityType + " p1) public {}}"
+	msg.Solidity = "pragma solidity >=0.4.22 <0.6.0; contract test {constructor(" + solidityType + " p1) public {}}"
 	msg.Parameters = []interface{}{val}
 	msg.From = "0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c"
 	msg.Nonce = "123"
@@ -281,18 +281,18 @@ func TestSolidityIntParamConversion(t *testing.T) {
 }
 
 func TestSolidityIntArrayParamConversion(t *testing.T) {
-	testComplexParam(t, "int8[]", []float64{123, 456, 789}, "")
-	testComplexParam(t, "int8[]", []float64{}, "")
-	testComplexParam(t, "int256[]", []float64{123, 456, 789}, "")
-	testComplexParam(t, "int256[]", []float64{}, "")
-	testComplexParam(t, "int256[]", float64(123), "Must supply an array")
-	testComplexParam(t, "uint8[]", []string{"123"}, "")
-	testComplexParam(t, "uint8[]", []string{"abc"}, "Could not be converted to a number")
+	testComplexParam(t, "int8[] memory", []float64{123, 456, 789}, "")
+	testComplexParam(t, "int8[] memory", []float64{}, "")
+	testComplexParam(t, "int256[] memory", []float64{123, 456, 789}, "")
+	testComplexParam(t, "int256[] memory", []float64{}, "")
+	testComplexParam(t, "int256[] memory", float64(123), "Must supply an array")
+	testComplexParam(t, "uint8[] memory", []string{"123"}, "")
+	testComplexParam(t, "uint8[] memory", []string{"abc"}, "Could not be converted to a number")
 }
 
 func TestSolidityStringParamConversion(t *testing.T) {
-	testComplexParam(t, "string", "ok", "")
-	testComplexParam(t, "string", float64(5), "Must supply a string")
+	testComplexParam(t, "string memory", "ok", "")
+	testComplexParam(t, "string memory", float64(5), "Must supply a string")
 }
 
 func TestSolidityBoolParamConversion(t *testing.T) {

--- a/internal/kldkafka/msgprocessor_test.go
+++ b/internal/kldkafka/msgprocessor_test.go
@@ -60,7 +60,7 @@ const testFromAddr = "0x83dBC8e329b38cBA0Fc4ed99b1Ce9c2a390ABdC1"
 
 var goodDeployTxnJSON = "{" +
 	"  \"headers\":{\"type\": \"DeployContract\"}," +
-	"  \"solidity\":\"pragma solidity ^0.4.17; contract t {constructor() public {}}\"," +
+	"  \"solidity\":\"pragma solidity >=0.4.22 <0.6.0; contract t {constructor() public {}}\"," +
 	"  \"from\":\"" + testFromAddr + "\"," +
 	"  \"nonce\":\"123\"," +
 	"  \"gas\":\"123\"" +

--- a/internal/kldwebhooks/webhooksbridge_test.go
+++ b/internal/kldwebhooks/webhooksbridge_test.go
@@ -463,7 +463,7 @@ func TestWebhookHandlerYAMLDeployContract(t *testing.T) {
 		"  type: DeployContract\n" +
 		"from: '0x4b098809E68C88e26442491c57866b7D4852216c'\n" +
 		"solidity: |-\n" +
-		"  pragma solidity ^0.4.17;\n" +
+		"  pragma solidity >=0.4.22 <0.6.0;\n" +
 		"  \n" +
 		"  contract simplestorage {\n" +
 		"    uint public storedData;\n" +


### PR DESCRIPTION
Was looking to give this a go for a trial run. 

Decided to update the tests to support the newest compiler versions expected syntax.  Is it this useful? 