### PR TITLE
privacyGroupId as input to orion private transaction

### DIFF
--- a/internal/kldcontracts/rest2eth.go
+++ b/internal/kldcontracts/rest2eth.go
@@ -409,7 +409,7 @@ func (r *rest2eth) doubleURLDecode(s string) string {
 	return strings.ReplaceAll(doubleDecoded, " ", "+")
 }
 
-func (r *rest2eth) addPrivateTx(msg *kldmessages.TransactionCommon, req *http.Request, res http.ResponseWriter) {
+func (r *rest2eth) addPrivateTx(msg *kldmessages.TransactionCommon, req *http.Request, res http.ResponseWriter) error {
 	msg.PrivateFrom = r.doubleURLDecode(getKLDParam("privatefrom", req, false))
 	msg.PrivateFor = getKLDParamMulti("privatefor", req)
 	for idx, val := range msg.PrivateFor {
@@ -417,10 +417,9 @@ func (r *rest2eth) addPrivateTx(msg *kldmessages.TransactionCommon, req *http.Re
 	}
 	msg.PrivacyGroupID = r.doubleURLDecode(getKLDParam("privacygroupid", req, false))
 	if len(msg.PrivateFor) > 0 && msg.PrivacyGroupID != "" {
-		err := fmt.Errorf("kld-privatefor and kld-privacygroupid are mutually exclusive")
-		r.restErrReply(res, req, err, 400)
-		return
+		return fmt.Errorf("kld-privatefor and kld-privacygroupid are mutually exclusive")
 	}
+	return nil
 }
 
 func (r *rest2eth) deployContract(res http.ResponseWriter, req *http.Request, from string, value json.Number, abiMethod *abi.Method, deployMsg *kldmessages.DeployContract, msgParams []interface{}) {
@@ -431,7 +430,10 @@ func (r *rest2eth) deployContract(res http.ResponseWriter, req *http.Request, fr
 	deployMsg.GasPrice = json.Number(getKLDParam("gasprice", req, false))
 	deployMsg.Value = value
 	deployMsg.Parameters = msgParams
-	r.addPrivateTx(&deployMsg.TransactionCommon, req, res)
+	if err := r.addPrivateTx(&deployMsg.TransactionCommon, req, res); err != nil {
+		r.restErrReply(res, req, err, 400)
+		return
+	}
 	deployMsg.RegisterAs = getKLDParam("register", req, false)
 	if deployMsg.RegisterAs != "" {
 		if err := r.gw.checkNameAvailable(deployMsg.RegisterAs, isRemote(deployMsg.Headers)); err != nil {
@@ -480,7 +482,10 @@ func (r *rest2eth) sendTransaction(res http.ResponseWriter, req *http.Request, f
 	msg.GasPrice = json.Number(getKLDParam("gasprice", req, false))
 	msg.Value = value
 	msg.Parameters = msgParams
-	r.addPrivateTx(&msg.TransactionCommon, req, res)
+	if err := r.addPrivateTx(&msg.TransactionCommon, req, res); err != nil {
+		r.restErrReply(res, req, err, 400)
+		return
+	}
 
 	if strings.ToLower(getKLDParam("sync", req, true)) == "true" {
 		responder := &rest2EthSyncResponder{

--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -113,7 +113,7 @@ func (g *smartContractGW) AddRoutes(router *httprouter.Router) {
 }
 
 // NewSmartContractGateway construtor
-func NewSmartContractGateway(conf *SmartContractGatewayConf, rpc kldeth.RPCClient, processor kldtx.TxnProcessor, asyncDispatcher REST2EthAsyncDispatcher) (SmartContractGateway, error) {
+func NewSmartContractGateway(conf *SmartContractGatewayConf, txnConf *kldtx.TxnProcessorConf, rpc kldeth.RPCClient, processor kldtx.TxnProcessor, asyncDispatcher REST2EthAsyncDispatcher) (SmartContractGateway, error) {
 	var baseURL *url.URL
 	var err error
 	if conf.BaseURL != "" {
@@ -125,7 +125,8 @@ func NewSmartContractGateway(conf *SmartContractGatewayConf, rpc kldeth.RPCClien
 		baseURL, _ = url.Parse("http://localhost:8080")
 	}
 	log.Infof("OpenAPI Smart Contract Gateway configured with base URL '%s'", baseURL.String())
-	abi2swagger := kldopenapi.NewABI2Swagger(baseURL.Host, baseURL.Path, []string{baseURL.Scheme})
+	// TODO - is there a way to access OrionPrivateAPIS cmdline flag here?
+	abi2swagger := kldopenapi.NewABI2Swagger(baseURL.Host, baseURL.Path, []string{baseURL.Scheme}, txnConf.OrionPrivateAPIS)
 	gw := &smartContractGW{
 		conf:                  conf,
 		rr:                    NewRemoteRegistry(&conf.RemoteRegistry),

--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -125,7 +125,6 @@ func NewSmartContractGateway(conf *SmartContractGatewayConf, txnConf *kldtx.TxnP
 		baseURL, _ = url.Parse("http://localhost:8080")
 	}
 	log.Infof("OpenAPI Smart Contract Gateway configured with base URL '%s'", baseURL.String())
-	// TODO - is there a way to access OrionPrivateAPIS cmdline flag here?
 	abi2swagger := kldopenapi.NewABI2Swagger(baseURL.Host, baseURL.Path, []string{baseURL.Scheme}, txnConf.OrionPrivateAPIS)
 	gw := &smartContractGW{
 		conf:                  conf,

--- a/internal/kldcontracts/smartcontractgw_test.go
+++ b/internal/kldcontracts/smartcontractgw_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/kaleido-io/ethconnect/internal/kldevents"
 	"github.com/kaleido-io/ethconnect/internal/kldmessages"
+	"github.com/kaleido-io/ethconnect/internal/kldtx"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -61,6 +62,9 @@ func TestNewSmartContractGatewayBadURL(t *testing.T) {
 		&SmartContractGatewayConf{
 			BaseURL: " :",
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
+		},
 		nil, nil, nil,
 	)
 }
@@ -75,6 +79,9 @@ func TestNewSmartContractGatewayWithEvents(t *testing.T) {
 			SubscriptionManagerConf: kldevents.SubscriptionManagerConf{
 				EventLevelDBPath: path.Join(dir, "db"),
 			},
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
 		},
 		nil, nil, nil,
 	)
@@ -94,6 +101,9 @@ func TestNewSmartContractGatewayWithEventsFail(t *testing.T) {
 			SubscriptionManagerConf: kldevents.SubscriptionManagerConf{
 				EventLevelDBPath: dbpath,
 			},
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
 		},
 		nil, nil, nil,
 	)
@@ -115,6 +125,9 @@ func TestPreDeployCompileAndPostDeploy(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 			BaseURL:     "http://localhost/api/v1",
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
 		},
 		nil, nil, nil,
 	)
@@ -229,6 +242,9 @@ func TestRegisterExistingContract(t *testing.T) {
 			StoragePath: dir,
 			BaseURL:     "http://localhost/api/v1",
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
+		},
 		nil, nil, nil,
 	)
 
@@ -283,6 +299,9 @@ func TestRemoteRegistrySwaggerOrABI(t *testing.T) {
 	scgw, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			BaseURL: "http://localhost/api/v1",
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)
@@ -382,6 +401,9 @@ func TestRegisterContractBadAddress(t *testing.T) {
 			StoragePath: dir,
 			BaseURL:     "http://localhost/api/v1",
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	router := &httprouter.Router{}
@@ -406,6 +428,9 @@ func TestRegisterContractNoRegisteredName(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 			BaseURL:     "http://localhost/api/v1",
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)
@@ -449,6 +474,9 @@ func TestRegisterContractBadABI(t *testing.T) {
 			StoragePath: dir,
 			BaseURL:     "http://localhost/api/v1",
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	router := &httprouter.Router{}
@@ -471,6 +499,9 @@ func TestLoadDeployMsgOKNoABIInIndex(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -490,6 +521,9 @@ func TestLoadDeployMsgMissing(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -504,6 +538,9 @@ func TestLoadDeployMsgFailure(t *testing.T) {
 	s, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			StoragePath: dir,
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)
@@ -522,6 +559,9 @@ func TestLoadDeployMsgRemoteLookupNotFound(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -536,6 +576,9 @@ func TestPreDeployCompileFailure(t *testing.T) {
 	s, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			StoragePath: "/anypath",
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)
@@ -554,6 +597,9 @@ func TestPreDeployMsgWrite(t *testing.T) {
 	s, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			StoragePath: path.Join(dir, "badpath"),
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)
@@ -574,6 +620,9 @@ func TestPostDeployNoRegisteredName(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 			BaseURL:     "http://localhost/api/v1",
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)
@@ -611,6 +660,9 @@ func TestPostDeployRemoteRegisteredName(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 			BaseURL:     "http://localhost/api/v1",
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)
@@ -655,6 +707,9 @@ func TestPostDeployRemoteRegisteredNameNotSuccess(t *testing.T) {
 			StoragePath: dir,
 			BaseURL:     "http://localhost/api/v1",
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	rr := &mockRR{}
@@ -697,6 +752,9 @@ func TestPostDeployMissingContractAddress(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -721,6 +779,9 @@ func TestStoreABIWriteFail(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: path.Join(dir, "badpath"),
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -740,6 +801,9 @@ func TestLoadABIForInstanceUnknown(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: path.Join(dir, "badpath"),
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -755,6 +819,9 @@ func TestLoadABIBadData(t *testing.T) {
 	s, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			StoragePath: dir,
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)
@@ -843,6 +910,9 @@ func TestBuildIndex(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -895,6 +965,9 @@ func TestGetContractOrABIFail(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -946,6 +1019,9 @@ func TestGetContractUI(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -976,6 +1052,9 @@ func TestAddABISingleSolidity(t *testing.T) {
 	s, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			StoragePath: dir,
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)
@@ -1011,6 +1090,9 @@ func TestAddABISingleSolidityBadContractName(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -1039,6 +1121,9 @@ func TestAddABIZipNested(t *testing.T) {
 	s, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			StoragePath: dir,
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)
@@ -1077,6 +1162,9 @@ func TestAddABIZipNestedListSolidity(t *testing.T) {
 	s, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			StoragePath: dir,
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)
@@ -1117,6 +1205,9 @@ func TestAddABIZipNestedListContracts(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -1156,6 +1247,9 @@ func TestAddABIBadZip(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -1189,6 +1283,9 @@ func TestAddABIZipNestedNoSource(t *testing.T) {
 	s, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			StoragePath: dir,
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)
@@ -1227,6 +1324,9 @@ func TestAddABIZiNotMultipart(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -1254,6 +1354,9 @@ func TestCompileMultipartFormSolidityBadDir(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -1271,6 +1374,9 @@ func TestCompileMultipartFormSolidityBadSolc(t *testing.T) {
 	s, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			StoragePath: dir,
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)
@@ -1294,6 +1400,9 @@ func TestCompileMultipartFormSolidityBadCompilerVerReq(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -1313,6 +1422,9 @@ func TestCompileMultipartFormSolidityBadSolidity(t *testing.T) {
 	s, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			StoragePath: dir,
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
 		},
 		nil, nil, nil,
 	)
@@ -1334,6 +1446,9 @@ func TestExtractMultiPartFileBadFile(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -1353,6 +1468,9 @@ func TestExtractMultiPartFileBadInput(t *testing.T) {
 	s, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			StoragePath: dir,
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
 		},
 		nil, nil, nil,
 	)
@@ -1374,6 +1492,9 @@ func TestStoreDeployableABIMissingABI(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -1390,6 +1511,9 @@ func TestAddFileToContractIndexBadFileSwallowsError(t *testing.T) {
 		&SmartContractGatewayConf{
 			StoragePath: dir,
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
+		},
 		nil, nil, nil,
 	)
 	scgw := s.(*smartContractGW)
@@ -1404,6 +1528,9 @@ func TestAddFileToContractIndexBadDataSwallowsError(t *testing.T) {
 	s, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			StoragePath: dir,
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
 		},
 		nil, nil, nil,
 	)
@@ -1421,6 +1548,9 @@ func TestAddFileToABIIndexBadFileSwallowsError(t *testing.T) {
 	s, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			StoragePath: dir,
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: true,
 		},
 		nil, nil, nil,
 	)
@@ -1671,6 +1801,9 @@ func TestCheckNameAvailableRRDuplicate(t *testing.T) {
 		&SmartContractGatewayConf{
 			BaseURL: "http://localhost/api/v1",
 		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
+		},
 		nil, nil, nil,
 	)
 	rr := &mockRR{
@@ -1689,6 +1822,9 @@ func TestCheckNameAvailableRRFail(t *testing.T) {
 	scgw, _ := NewSmartContractGateway(
 		&SmartContractGatewayConf{
 			BaseURL: "http://localhost/api/v1",
+		},
+		&kldtx.TxnProcessorConf{
+			OrionPrivateAPIS: false,
 		},
 		nil, nil, nil,
 	)

--- a/internal/kldeth/compiler.go
+++ b/internal/kldeth/compiler.go
@@ -113,7 +113,7 @@ func CompileContract(soliditySource, contractName, requestedVersion, evmVersion 
 	cmd.Stderr = &stderr
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("Solidity compilation failed: solc: %v\n%s", err, stderr.Bytes())
+		return nil, fmt.Errorf("Solidity compilation failed: solc: %v\n%s", err, stderr.String())
 	}
 	c, err := compiler.ParseCombinedJSON(stdout.Bytes(), soliditySource, s.Version, s.Version, strings.Join(solcArgs, " "))
 	return ProcessCompiled(c, contractName, true)

--- a/internal/kldeth/getreceipt.go
+++ b/internal/kldeth/getreceipt.go
@@ -37,7 +37,8 @@ func (tx *Txn) GetTXReceipt(rpc RPCClient) (bool, error) {
 	log.Debugf("eth_getTransactionReceipt(%x,latest)=%t [%.2fs]", tx.Hash, isMined, callTime.Seconds())
 
 	if tx.PrivacyGroupID != "" {
-		if err := rpc.CallContext(ctx, &tx.Receipt, "priv_getTransactionReceipt", tx.Hash); err != nil {
+		// priv_getTransactionReceipt expects the txHash and the public key of enclave (privateFrom)
+		if err := rpc.CallContext(ctx, &tx.Receipt, "priv_getTransactionReceipt", tx.Hash, tx.PrivateFrom); err != nil {
 			return false, fmt.Errorf("priv_getTransactionReceipt returned: %s", err)
 		}
 	}

--- a/internal/kldeth/getreceipt_test.go
+++ b/internal/kldeth/getreceipt_test.go
@@ -89,6 +89,7 @@ func TestGetTXReceiptOrionTX(t *testing.T) {
 
 	tx := Txn{
 		PrivacyGroupID: "test",
+		PrivateFrom:    "foo",
 	}
 	var blockNumber hexutil.Big
 	blockNumber.ToInt().SetInt64(10)
@@ -113,6 +114,7 @@ func TestGetTXReceiptOrionTXFail(t *testing.T) {
 
 	tx := Txn{
 		PrivacyGroupID: "test",
+		PrivateFrom:    "foo",
 	}
 	var blockNumber hexutil.Big
 	blockNumber.ToInt().SetInt64(10)

--- a/internal/kldeth/txn.go
+++ b/internal/kldeth/txn.go
@@ -109,6 +109,7 @@ func NewContractDeployTxn(msg *kldmessages.DeployContract) (tx *Txn, err error) 
 	// retain private transaction fields
 	tx.PrivateFrom = msg.PrivateFrom
 	tx.PrivateFor = msg.PrivateFor
+	tx.PrivacyGroupID = msg.PrivacyGroupID
 	return
 }
 

--- a/internal/kldeth/txn.go
+++ b/internal/kldeth/txn.go
@@ -81,7 +81,7 @@ func NewContractDeployTxn(msg *kldmessages.DeployContract) (tx *Txn, err error) 
 			return
 		}
 	} else {
-		err = fmt.Errorf("Missing Compliled Code + ABI, or Solidity")
+		err = fmt.Errorf("Missing Compiled Code + ABI, or Solidity")
 		return
 	}
 

--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -255,7 +255,7 @@ func TestNewContractDeployMissingCompiledOrSolidity(t *testing.T) {
 	msg.Gas = "456"
 	msg.GasPrice = "789"
 	_, err := NewContractDeployTxn(&msg)
-	assert.EqualError(err, "Missing Compliled Code + ABI, or Solidity")
+	assert.EqualError(err, "Missing Compiled Code + ABI, or Solidity")
 }
 
 func TestNewContractDeployPrecompiledSimpleStorage(t *testing.T) {

--- a/internal/kldmessages/messages.go
+++ b/internal/kldmessages/messages.go
@@ -111,17 +111,20 @@ func (r *TransactionReceipt) IsReceipt() *TransactionReceipt {
 }
 
 // TransactionCommon is the common fields from https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethsendtransaction
-// for sending either contract call or creation transactions
+// for sending either contract call or creation transactions, with eea extensions for private transactions
+// from https://entethalliance.github.io/client-spec/spec.html#sec-eea-sendTransaction
+// TODO - do Orion/Tessera support "unrestricted" private transactions?
 type TransactionCommon struct {
 	RequestCommon
-	Nonce       json.Number   `json:"nonce,omitempty"`
-	From        string        `json:"from"`
-	Value       json.Number   `json:"value"`
-	Gas         json.Number   `json:"gas"`
-	GasPrice    json.Number   `json:"gasPrice"`
-	Parameters  []interface{} `json:"params"`
-	PrivateFrom string        `json:"privateFrom,omitempty"`
-	PrivateFor  []string      `json:"privateFor,omitempty"`
+	Nonce          json.Number   `json:"nonce,omitempty"`
+	From           string        `json:"from"`
+	Value          json.Number   `json:"value"`
+	Gas            json.Number   `json:"gas"`
+	GasPrice       json.Number   `json:"gasPrice"`
+	Parameters     []interface{} `json:"params"`
+	PrivateFrom    string        `json:"privateFrom,omitempty"`
+	PrivateFor     []string      `json:"privateFor,omitempty"`
+	PrivacyGroupID string        `json:"privacyGroupId,omitempty"`
 }
 
 // SendTransaction message instructs the bridge to install a contract

--- a/internal/kldopenapi/abi2swagger.go
+++ b/internal/kldopenapi/abi2swagger.go
@@ -341,7 +341,7 @@ func (c *ABI2Swagger) getCommonParameters() map[string]spec.Parameter {
 	params["privacyGroupIdParam"] = spec.Parameter{
 		ParamProps: spec.ParamProps{
 			Description:     "Private transaction group ID - 'x-kaleido-privacyGroupId' header can also be used",
-			Name:            "kld-privacyGroupId",
+			Name:            "kld-privacygroupid",
 			In:              "query",
 			Required:        false,
 			AllowEmptyValue: false,

--- a/internal/kldopenapi/abi2swagger.go
+++ b/internal/kldopenapi/abi2swagger.go
@@ -30,6 +30,7 @@ type ABI2Swagger struct {
 	externalHost     string
 	externalSchemes  []string
 	externalRootPath string
+	orionPrivateAPI  bool
 }
 
 const (
@@ -37,11 +38,12 @@ const (
 )
 
 // NewABI2Swagger constructor
-func NewABI2Swagger(externalHost, externalRootPath string, externalSchemes []string) *ABI2Swagger {
+func NewABI2Swagger(externalHost, externalRootPath string, externalSchemes []string, orionPrivateAPI bool) *ABI2Swagger {
 	c := &ABI2Swagger{
 		externalHost:     externalHost,
 		externalRootPath: externalRootPath,
 		externalSchemes:  externalSchemes,
+		orionPrivateAPI:  orionPrivateAPI,
 	}
 	if len(c.externalSchemes) == 0 {
 		c.externalSchemes = []string{"http", "https"}
@@ -418,11 +420,13 @@ func (c *ABI2Swagger) addCommonParams(op *spec.Operation, isPOST bool, isConstru
 				Ref: privateForParam,
 			},
 		})
-		op.Parameters = append(op.Parameters, spec.Parameter{
-			Refable: spec.Refable{
-				Ref: privacyGroupIdParam,
-			},
-		})
+		if c.orionPrivateAPI {
+			op.Parameters = append(op.Parameters, spec.Parameter{
+				Refable: spec.Refable{
+					Ref: privacyGroupIdParam,
+				},
+			})
+		}
 	}
 	if isConstructor {
 		op.Parameters = append(op.Parameters, spec.Parameter{

--- a/internal/kldopenapi/abi2swagger.go
+++ b/internal/kldopenapi/abi2swagger.go
@@ -336,6 +336,18 @@ func (c *ABI2Swagger) getCommonParameters() map[string]spec.Parameter {
 			Type: "string",
 		},
 	}
+	params["privacyGroupIdParam"] = spec.Parameter{
+		ParamProps: spec.ParamProps{
+			Description:     "Private transaction group ID - 'x-kaleido-privacyGroupId' header can also be used",
+			Name:            "kld-privacyGroupId",
+			In:              "query",
+			Required:        false,
+			AllowEmptyValue: false,
+		},
+		SimpleSchema: spec.SimpleSchema{
+			Type: "string",
+		},
+	}
 	params["registerParam"] = spec.Parameter{
 		ParamProps: spec.ParamProps{
 			Description:     "Register the installed contract on a friendly path (overwrites existing) - 'x-kaleido-register' header can also be used",
@@ -363,6 +375,7 @@ func (c *ABI2Swagger) addCommonParams(op *spec.Operation, isPOST bool, isConstru
 	callParam, _ := spec.NewRef("#/parameters/callParam")
 	privateFromParam, _ := spec.NewRef("#/parameters/privateFromParam")
 	privateForParam, _ := spec.NewRef("#/parameters/privateForParam")
+	privacyGroupIdParam, _ := spec.NewRef("#/parameters/privacyGroupIdParam")
 	registerParam, _ := spec.NewRef("#/parameters/registerParam")
 	op.Parameters = append(op.Parameters, spec.Parameter{
 		Refable: spec.Refable{
@@ -403,6 +416,11 @@ func (c *ABI2Swagger) addCommonParams(op *spec.Operation, isPOST bool, isConstru
 		op.Parameters = append(op.Parameters, spec.Parameter{
 			Refable: spec.Refable{
 				Ref: privateForParam,
+			},
+		})
+		op.Parameters = append(op.Parameters, spec.Parameter{
+			Refable: spec.Refable{
+				Ref: privacyGroupIdParam,
 			},
 		})
 	}

--- a/internal/kldopenapi/abi2swagger_test.go
+++ b/internal/kldopenapi/abi2swagger_test.go
@@ -35,7 +35,7 @@ const (
 func TestABI2SwaggerERC20Generic(t *testing.T) {
 	assert := assert.New(t)
 
-	c := NewABI2Swagger("localhost:80", "/contracts", []string{"http"})
+	c := NewABI2Swagger("localhost:80", "/contracts", []string{"http"}, true)
 	abi, err := abi.JSON(strings.NewReader(erc20ABI))
 	assert.NoError(err)
 	swagger := c.Gen4Factory("/erc20", "erc20", false, false, &abi, erc20DevDocs)
@@ -52,7 +52,7 @@ func TestABI2SwaggerERC20Generic(t *testing.T) {
 func TestABI2SwaggerERC20GenericFactoryOnly(t *testing.T) {
 	assert := assert.New(t)
 
-	c := NewABI2Swagger("localhost:80", "/contracts", []string{"http"})
+	c := NewABI2Swagger("localhost:80", "/contracts", []string{"http"}, false)
 	abi, err := abi.JSON(strings.NewReader(erc20ABI))
 	assert.NoError(err)
 	swagger := c.Gen4Factory("/erc20", "erc20", true, false, &abi, erc20DevDocs)
@@ -64,7 +64,7 @@ func TestABI2SwaggerERC20GenericFactoryOnly(t *testing.T) {
 func TestABI2SwaggerLotsOfTypesInstance(t *testing.T) {
 	assert := assert.New(t)
 
-	c := NewABI2Swagger("localhost", "/contracts", nil)
+	c := NewABI2Swagger("localhost", "/contracts", nil, true)
 	abi, err := abi.JSON(strings.NewReader(lotsOfTypesABI))
 	assert.NoError(err)
 	swagger := c.Gen4Instance("/0x0123456789abcdef0123456789abcdef0123456", "lotsOfTypes", &abi, lotsOfTypesDevDocs)

--- a/internal/kldrest/restgateway.go
+++ b/internal/kldrest/restgateway.go
@@ -217,7 +217,7 @@ func (g *RESTGateway) Start() (err error) {
 	}
 
 	if g.conf.OpenAPI.StoragePath != "" {
-		g.smartContractGW, err = kldcontracts.NewSmartContractGateway(&g.conf.OpenAPI, rpcClient, processor, g)
+		g.smartContractGW, err = kldcontracts.NewSmartContractGateway(&g.conf.OpenAPI, &g.conf.TxnProcessorConf, rpcClient, processor, g)
 		if err != nil {
 			return err
 		}

--- a/internal/kldtx/txnprocessor_test.go
+++ b/internal/kldtx/txnprocessor_test.go
@@ -44,10 +44,10 @@ type errorReply struct {
 }
 
 type testTxnContext struct {
-	jsonMsg     string
-	badMsgType  string
-	replies     []kldmessages.ReplyWithHeaders
-	errorRepies []*errorReply
+	jsonMsg      string
+	badMsgType   string
+	replies      []kldmessages.ReplyWithHeaders
+	errorReplies []*errorReply
 }
 
 type testRPC struct {
@@ -135,7 +135,7 @@ func (c *testTxnContext) SendErrorReply(status int, err error) {
 
 func (c *testTxnContext) SendErrorReplyWithTX(status int, err error, txHash string) {
 	log.Infof("Sending error reply. Status=%d Err=%s", status, err)
-	c.errorRepies = append(c.errorRepies, &errorReply{
+	c.errorReplies = append(c.errorReplies, &errorReply{
 		status: status,
 		err:    err,
 		txHash: txHash,
@@ -158,9 +158,9 @@ func TestOnMessageBadMessage(t *testing.T) {
 	txnProcessor.OnMessage(testTxnContext)
 
 	assert.Empty(testTxnContext.replies)
-	assert.NotEmpty(testTxnContext.errorRepies)
-	assert.Equal(400, testTxnContext.errorRepies[0].status)
-	assert.Regexp("Unknown message type", testTxnContext.errorRepies[0].err.Error())
+	assert.NotEmpty(testTxnContext.errorReplies)
+	assert.Equal(400, testTxnContext.errorReplies[0].status)
+	assert.Regexp("Unknown message type", testTxnContext.errorReplies[0].err.Error())
 }
 
 func TestOnDeployContractMessageBadMsg(t *testing.T) {
@@ -175,9 +175,9 @@ func TestOnDeployContractMessageBadMsg(t *testing.T) {
 		"}"
 	txnProcessor.OnMessage(testTxnContext)
 
-	assert.NotEmpty(testTxnContext.errorRepies)
+	assert.NotEmpty(testTxnContext.errorReplies)
 	assert.Empty(testTxnContext.replies)
-	assert.Equal("Missing Compliled Code + ABI, or Solidity", testTxnContext.errorRepies[0].err.Error())
+	assert.Equal("Missing Compiled Code + ABI, or Solidity", testTxnContext.errorReplies[0].err.Error())
 
 }
 func TestOnDeployContractMessageBadJSON(t *testing.T) {
@@ -189,9 +189,9 @@ func TestOnDeployContractMessageBadJSON(t *testing.T) {
 	testTxnContext.badMsgType = kldmessages.MsgTypeDeployContract
 	txnProcessor.OnMessage(testTxnContext)
 
-	assert.NotEmpty(testTxnContext.errorRepies)
+	assert.NotEmpty(testTxnContext.errorReplies)
 	assert.Empty(testTxnContext.replies)
-	assert.Regexp("invalid character", testTxnContext.errorRepies[0].err.Error())
+	assert.Regexp("invalid character", testTxnContext.errorReplies[0].err.Error())
 
 }
 func TestOnDeployContractMessageGoodTxnErrOnReceipt(t *testing.T) {
@@ -213,12 +213,12 @@ func TestOnDeployContractMessageGoodTxnErrOnReceipt(t *testing.T) {
 	txnWG := &txnProcessor.inflightTxns[strings.ToLower(testFromAddr)][0].wg
 
 	txnWG.Wait()
-	assert.Equal(1, len(testTxnContext.errorRepies))
+	assert.Equal(1, len(testTxnContext.errorReplies))
 
 	assert.Equal("eth_sendTransaction", testRPC.calls[0])
 	assert.Equal("eth_getTransactionReceipt", testRPC.calls[1])
 
-	assert.Regexp("Error obtaining transaction receipt", testTxnContext.errorRepies[0].err.Error())
+	assert.Regexp("Error obtaining transaction receipt", testTxnContext.errorReplies[0].err.Error())
 
 }
 
@@ -268,7 +268,7 @@ func TestOnDeployContractMessageGoodTxnMined(t *testing.T) {
 	txnWG := &txnProcessor.inflightTxns[strings.ToLower(testFromAddr)][0].wg
 
 	txnWG.Wait()
-	assert.Equal(0, len(testTxnContext.errorRepies))
+	assert.Equal(0, len(testTxnContext.errorReplies))
 
 	assert.Equal("eth_sendTransaction", testRPC.calls[0])
 	assert.Equal("eth_getTransactionReceipt", testRPC.calls[1])
@@ -308,7 +308,7 @@ func TestOnDeployContractPrivateMessageGoodTxnMined(t *testing.T) {
 	txnWG := &txnProcessor.inflightTxns[strings.ToLower(testFromAddr)][0].wg
 
 	txnWG.Wait()
-	assert.Equal(0, len(testTxnContext.errorRepies))
+	assert.Equal(0, len(testTxnContext.errorReplies))
 
 	assert.Equal("eth_sendTransaction", testRPC.calls[0])
 	sendTxArg0JSON, _ := json.Marshal(testRPC.params[0][0])
@@ -354,7 +354,7 @@ func TestOnDeployContractMessageGoodTxnMinedWithHex(t *testing.T) {
 	txnWG := &txnProcessor.inflightTxns[strings.ToLower(testFromAddr)][0].wg
 
 	txnWG.Wait()
-	assert.Equal(0, len(testTxnContext.errorRepies))
+	assert.Equal(0, len(testTxnContext.errorReplies))
 
 	assert.Equal("eth_sendTransaction", testRPC.calls[0])
 	assert.Equal("eth_getTransactionReceipt", testRPC.calls[1])
@@ -421,7 +421,7 @@ func TestOnDeployContractMessageFailedTxn(t *testing.T) {
 
 	txnProcessor.OnMessage(testTxnContext)
 
-	assert.Equal("fizzle", testTxnContext.errorRepies[0].err.Error())
+	assert.Equal("fizzle", testTxnContext.errorReplies[0].err.Error())
 	assert.EqualValues([]string{"eth_sendTransaction"}, testRPC.calls)
 }
 
@@ -444,7 +444,7 @@ func TestOnDeployContractMessageFailedToGetNonce(t *testing.T) {
 
 	txnProcessor.OnMessage(testTxnContext)
 
-	assert.Equal("eth_getTransactionCount returned: ding", testTxnContext.errorRepies[0].err.Error())
+	assert.Equal("eth_getTransactionCount returned: ding", testTxnContext.errorReplies[0].err.Error())
 	assert.EqualValues([]string{"eth_getTransactionCount"}, testRPC.calls)
 }
 
@@ -459,9 +459,9 @@ func TestOnSendTransactionMessageMissingFrom(t *testing.T) {
 		"}"
 	txnProcessor.OnMessage(testTxnContext)
 
-	assert.NotEmpty(testTxnContext.errorRepies)
+	assert.NotEmpty(testTxnContext.errorReplies)
 	assert.Empty(testTxnContext.replies)
-	assert.Regexp("'from' must be supplied", testTxnContext.errorRepies[0].err.Error())
+	assert.Regexp("'from' must be supplied", testTxnContext.errorReplies[0].err.Error())
 
 }
 
@@ -477,9 +477,9 @@ func TestOnSendTransactionMessageBadNonce(t *testing.T) {
 		"}"
 	txnProcessor.OnMessage(testTxnContext)
 
-	assert.NotEmpty(testTxnContext.errorRepies)
+	assert.NotEmpty(testTxnContext.errorReplies)
 	assert.Empty(testTxnContext.replies)
-	assert.Regexp("Converting supplied 'nonce' to integer", testTxnContext.errorRepies[0].err.Error())
+	assert.Regexp("Converting supplied 'nonce' to integer", testTxnContext.errorReplies[0].err.Error())
 
 }
 
@@ -497,9 +497,9 @@ func TestOnSendTransactionMessageBadMsg(t *testing.T) {
 		"}"
 	txnProcessor.OnMessage(testTxnContext)
 
-	assert.NotEmpty(testTxnContext.errorRepies)
+	assert.NotEmpty(testTxnContext.errorReplies)
 	assert.Empty(testTxnContext.replies)
-	assert.Regexp("Converting supplied 'value' to big integer", testTxnContext.errorRepies[0].err.Error())
+	assert.Regexp("Converting supplied 'value' to big integer", testTxnContext.errorReplies[0].err.Error())
 
 }
 
@@ -512,9 +512,9 @@ func TestOnSendTransactionMessageBadJSON(t *testing.T) {
 	testTxnContext.badMsgType = kldmessages.MsgTypeSendTransaction
 	txnProcessor.OnMessage(testTxnContext)
 
-	assert.NotEmpty(testTxnContext.errorRepies)
+	assert.NotEmpty(testTxnContext.errorReplies)
 	assert.Empty(testTxnContext.replies)
-	assert.Regexp("invalid character", testTxnContext.errorRepies[0].err.Error())
+	assert.Regexp("invalid character", testTxnContext.errorReplies[0].err.Error())
 
 }
 
@@ -536,13 +536,13 @@ func TestOnSendTransactionMessageTxnTimeout(t *testing.T) {
 	txnProcessor.OnMessage(testTxnContext)
 	txnWG := &txnProcessor.inflightTxns[strings.ToLower(testFromAddr)][0].wg
 	txnWG.Wait()
-	assert.Equal(1, len(testTxnContext.errorRepies))
+	assert.Equal(1, len(testTxnContext.errorReplies))
 
 	assert.Equal("eth_sendTransaction", testRPC.calls[0])
 	assert.Equal("eth_getTransactionReceipt", testRPC.calls[1])
 
-	assert.Regexp("Timed out waiting for transaction receipt", testTxnContext.errorRepies[0].err.Error())
-	assert.Equal(txHash, testTxnContext.errorRepies[0].txHash)
+	assert.Regexp("Timed out waiting for transaction receipt", testTxnContext.errorReplies[0].err.Error())
+	assert.Equal(txHash, testTxnContext.errorReplies[0].txHash)
 
 }
 
@@ -561,7 +561,7 @@ func TestOnSendTransactionMessageFailedTxn(t *testing.T) {
 
 	txnProcessor.OnMessage(testTxnContext)
 
-	assert.Equal("pop", testTxnContext.errorRepies[0].err.Error())
+	assert.Equal("pop", testTxnContext.errorReplies[0].err.Error())
 	assert.EqualValues([]string{"eth_sendTransaction"}, testRPC.calls)
 }
 
@@ -584,7 +584,7 @@ func TestOnSendTransactionMessageFailedToGetNonce(t *testing.T) {
 
 	txnProcessor.OnMessage(testTxnContext)
 
-	assert.Equal("eth_getTransactionCount returned: poof", testTxnContext.errorRepies[0].err.Error())
+	assert.Equal("eth_getTransactionCount returned: poof", testTxnContext.errorReplies[0].err.Error())
 	assert.EqualValues([]string{"eth_getTransactionCount"}, testRPC.calls)
 }
 
@@ -610,8 +610,31 @@ func TestOnSendTransactionMessageInflightNonce(t *testing.T) {
 
 	txnProcessor.OnMessage(testTxnContext)
 
-	assert.Empty(testTxnContext.errorRepies)
+	assert.Empty(testTxnContext.errorReplies)
 	assert.EqualValues([]string{"eth_sendTransaction"}, testRPC.calls)
+}
+
+func TestOnSendTransactionMessageOrionCannotUsePrivacyGroupIdAndPrivateFor(t *testing.T) {
+	assert := assert.New(t)
+
+	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
+		OrionPrivateAPIS: true,
+	}).(*txnProcessor)
+	testTxnContext := &testTxnContext{}
+	testTxnContext.jsonMsg = "{" +
+		"  \"headers\":{\"type\": \"SendTransaction\"}," +
+		"  \"from\":\"0x83dBC8e329b38cBA0Fc4ed99b1Ce9c2a390ABdC1\"," +
+		"  \"gas\":\"123\"," +
+		"  \"method\":{\"name\":\"test\"}," +
+		"  \"privateFrom\":\"jO6dpqnMhmnrCHqUumyK09+18diF7quq/rROGs2HFWI=\"," +
+		"  \"privateFor\":[\"2QiZG7rYPzRvRsioEn6oYUff1DOvPA22EZr0+/o3RUg=\"]," +
+		"  \"privacyGroupId\":\"o6fFj1vwysfp92Xt2GZlVuq14KX9HWn7oVJ+64Mfoic=\"" +
+		"}"
+	txnProcessor.OnMessage(testTxnContext)
+
+	assert.NotEmpty(testTxnContext.errorReplies)
+	assert.Empty(testTxnContext.replies)
+	assert.Regexp("privacyGroupId and privateFor are mutually exclusive", testTxnContext.errorReplies[0].err.Error())
 }
 
 func TestOnSendTransactionMessageOrion(t *testing.T) {
@@ -644,8 +667,37 @@ func TestOnSendTransactionMessageOrion(t *testing.T) {
 
 	txnProcessor.OnMessage(testTxnContext)
 
-	assert.Empty(testTxnContext.errorRepies)
+	assert.Empty(testTxnContext.errorReplies)
 	assert.EqualValues([]string{"priv_findPrivacyGroup", "priv_getTransactionCount", "eth_sendTransaction"}, testRPC.calls)
+}
+
+func TestOnSendTransactionMessageOrionPrivacyGroupId(t *testing.T) {
+	assert := assert.New(t)
+
+	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
+		MaxTXWaitTime:    1,
+		OrionPrivateAPIS: true,
+	}).(*txnProcessor)
+	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"] =
+		[]*inflightTxn{&inflightTxn{nonce: 100}, &inflightTxn{nonce: 101}}
+	testTxnContext := &testTxnContext{}
+	testTxnContext.jsonMsg = "{" +
+		"  \"headers\":{\"type\": \"SendTransaction\"}," +
+		"  \"from\":\"0x83dBC8e329b38cBA0Fc4ed99b1Ce9c2a390ABdC1\"," +
+		"  \"gas\":\"123\"," +
+		"  \"method\":{\"name\":\"test\"}," +
+		"  \"privateFrom\":\"jO6dpqnMhmnrCHqUumyK09+18diF7quq/rROGs2HFWI=\"," +
+		"  \"privacyGroupId\":\"P8SxRUussJKqZu4+nUkMJpscQeWOR3HqbAXLakatsk8=\"" +
+		"}"
+	testRPC := &testRPC{
+		ethSendTransactionResult: "0xac18e98664e160305cdb77e75e5eae32e55447e94ad8ceb0123729589ed09f8b",
+	}
+	txnProcessor.Init(testRPC)
+
+	txnProcessor.OnMessage(testTxnContext)
+
+	assert.Empty(testTxnContext.errorReplies)
+	assert.EqualValues([]string{"priv_getTransactionCount", "eth_sendTransaction"}, testRPC.calls)
 }
 
 func TestCobraInitTxnProcessor(t *testing.T) {

--- a/internal/kldtx/txnprocessor_test.go
+++ b/internal/kldtx/txnprocessor_test.go
@@ -619,7 +619,7 @@ func TestOnSendTransactionMessageOrionNoPrivacyGroup(t *testing.T) {
 
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		OrionPrivateAPIS: true,
-	}).(*txnProcessor)
+	}, &kldeth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = "{" +
 		"  \"headers\":{\"type\": \"SendTransaction\"}," +
@@ -646,7 +646,7 @@ func TestOnSendTransactionMessageOrionCannotUsePrivacyGroupIdAndPrivateFor(t *te
 
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		OrionPrivateAPIS: true,
-	}).(*txnProcessor)
+	}, &kldeth.RPCConf{}).(*txnProcessor)
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = "{" +
 		"  \"headers\":{\"type\": \"SendTransaction\"}," +
@@ -704,7 +704,7 @@ func TestOnSendTransactionMessageOrionPrivacyGroupId(t *testing.T) {
 	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
 		MaxTXWaitTime:    1,
 		OrionPrivateAPIS: true,
-	}).(*txnProcessor)
+	}, &kldeth.RPCConf{}).(*txnProcessor)
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"] =
 		[]*inflightTxn{&inflightTxn{nonce: 100}, &inflightTxn{nonce: 101}}
 	testTxnContext := &testTxnContext{}
@@ -780,5 +780,5 @@ func TestOnSendTransactionAddressBook(t *testing.T) {
 
 	txnProcessor.OnMessage(testTxnContext)
 
-	assert.EqualError(testTxnContext.errorRepies[0].err, "500 Internal Server Error ")
+	assert.EqualError(testTxnContext.errorReplies[0].err, "500 Internal Server Error ")
 }

--- a/test/erc20.swagger.json
+++ b/test/erc20.swagger.json
@@ -61,6 +61,9 @@
             "$ref": "#/parameters/privateForParam"
           },
           {
+            "$ref": "#/parameters/privacyGroupIdParam"
+          },
+          {
             "$ref": "#/parameters/registerParam"
           }
         ],
@@ -444,6 +447,9 @@
           },
           {
             "$ref": "#/parameters/privateForParam"
+          },
+          {
+            "$ref": "#/parameters/privacyGroupIdParam"
           }
         ],
         "responses": {
@@ -580,6 +586,9 @@
           },
           {
             "$ref": "#/parameters/privateForParam"
+          },
+          {
+            "$ref": "#/parameters/privacyGroupIdParam"
           }
         ],
         "responses": {
@@ -709,6 +718,9 @@
           },
           {
             "$ref": "#/parameters/privateForParam"
+          },
+          {
+            "$ref": "#/parameters/privacyGroupIdParam"
           }
         ],
         "responses": {
@@ -845,6 +857,9 @@
           },
           {
             "$ref": "#/parameters/privateForParam"
+          },
+          {
+            "$ref": "#/parameters/privacyGroupIdParam"
           }
         ],
         "responses": {
@@ -981,6 +996,9 @@
           },
           {
             "$ref": "#/parameters/privateForParam"
+          },
+          {
+            "$ref": "#/parameters/privacyGroupIdParam"
           }
         ],
         "responses": {
@@ -1103,6 +1121,9 @@
           },
           {
             "$ref": "#/parameters/privateForParam"
+          },
+          {
+            "$ref": "#/parameters/privacyGroupIdParam"
           }
         ],
         "responses": {
@@ -1239,6 +1260,9 @@
           },
           {
             "$ref": "#/parameters/privateForParam"
+          },
+          {
+            "$ref": "#/parameters/privacyGroupIdParam"
           }
         ],
         "responses": {
@@ -1382,6 +1406,9 @@
           },
           {
             "$ref": "#/parameters/privateForParam"
+          },
+          {
+            "$ref": "#/parameters/privacyGroupIdParam"
           }
         ],
         "responses": {
@@ -1644,6 +1671,12 @@
       "name": "kld-gasprice",
       "in": "query",
       "allowEmptyValue": true
+    },
+    "privacyGroupIdParam": {
+      "type": "string",
+      "description": "Private transaction group ID - 'x-kaleido-privacyGroupId' header can also be used",
+      "name": "kld-privacyGroupId",
+      "in": "query"
     },
     "privateForParam": {
       "type": "string",

--- a/test/erc20.swagger.json
+++ b/test/erc20.swagger.json
@@ -1675,7 +1675,7 @@
     "privacyGroupIdParam": {
       "type": "string",
       "description": "Private transaction group ID - 'x-kaleido-privacyGroupId' header can also be used",
-      "name": "kld-privacyGroupId",
+      "name": "kld-privacygroupid",
       "in": "query"
     },
     "privateForParam": {

--- a/test/lotsoftypes.swagger.json
+++ b/test/lotsoftypes.swagger.json
@@ -151,6 +151,9 @@
           },
           {
             "$ref": "#/parameters/privateForParam"
+          },
+          {
+            "$ref": "#/parameters/privacyGroupIdParam"
           }
         ],
         "responses": {
@@ -308,6 +311,9 @@
           },
           {
             "$ref": "#/parameters/privateForParam"
+          },
+          {
+            "$ref": "#/parameters/privacyGroupIdParam"
           }
         ],
         "responses": {
@@ -456,6 +462,9 @@
           },
           {
             "$ref": "#/parameters/privateForParam"
+          },
+          {
+            "$ref": "#/parameters/privacyGroupIdParam"
           }
         ],
         "responses": {
@@ -758,6 +767,12 @@
       "name": "kld-gasprice",
       "in": "query",
       "allowEmptyValue": true
+    },
+    "privacyGroupIdParam": {
+      "type": "string",
+      "description": "Private transaction group ID - 'x-kaleido-privacyGroupId' header can also be used",
+      "name": "kld-privacyGroupId",
+      "in": "query"
     },
     "privateForParam": {
       "type": "string",

--- a/test/lotsoftypes.swagger.json
+++ b/test/lotsoftypes.swagger.json
@@ -771,7 +771,7 @@
     "privacyGroupIdParam": {
       "type": "string",
       "description": "Private transaction group ID - 'x-kaleido-privacyGroupId' header can also be used",
-      "name": "kld-privacyGroupId",
+      "name": "kld-privacygroupid",
       "in": "query"
     },
     "privateForParam": {


### PR DESCRIPTION
* privateFor[] and privacyGroupId are treated mutually exclusive (cannot
supply both
* adds privacyGroupId to swagger input
*  Fix parameters to priv_getTransactionReceipt