### PR TITLE
Support additional filter options on /replies

### DIFF
--- a/internal/kldrest/memreceipts.go
+++ b/internal/kldrest/memreceipts.go
@@ -37,11 +37,11 @@ func newMemoryReceipts(conf *ReceiptStoreConf) *memoryReceipts {
 	return r
 }
 
-func (m *memoryReceipts) GetReceipts(skip, limit int, ids []string, since, from, to string) (*[]map[string]interface{}, error) {
+func (m *memoryReceipts) GetReceipts(skip, limit int, ids []string, sinceEpochMS int64, from, to string) (*[]map[string]interface{}, error) {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
-	if len(ids) > 0 || since != "" || from != "" || to != "" {
+	if len(ids) > 0 || sinceEpochMS != 0 || from != "" || to != "" {
 		return nil, fmt.Errorf("Memory receipts do not support filtering")
 	}
 

--- a/internal/kldrest/memreceipts.go
+++ b/internal/kldrest/memreceipts.go
@@ -37,12 +37,12 @@ func newMemoryReceipts(conf *ReceiptStoreConf) *memoryReceipts {
 	return r
 }
 
-func (m *memoryReceipts) GetReceipts(skip, limit int, ids []string) (*[]map[string]interface{}, error) {
+func (m *memoryReceipts) GetReceipts(skip, limit int, ids []string, since, from, to string) (*[]map[string]interface{}, error) {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
-	if len(ids) > 0 {
-		return nil, fmt.Errorf("Memory receipts do not support id filtering")
+	if len(ids) > 0 || since != "" || from != "" || to != "" {
+		return nil, fmt.Errorf("Memory receipts do not support filtering")
 	}
 
 	results := make([]map[string]interface{}, 0, limit)

--- a/internal/kldrest/memreceipts_test.go
+++ b/internal/kldrest/memreceipts_test.go
@@ -55,8 +55,8 @@ func TestMemReceiptsNoIDFilterImpl(t *testing.T) {
 	}
 	r := newMemoryReceipts(conf)
 
-	_, err := r.GetReceipts(0, 0, []string{"test"})
-	assert.EqualError(err, "Memory receipts do not support id filtering")
+	_, err := r.GetReceipts(0, 0, []string{"test"}, "t", "t", "t")
+	assert.EqualError(err, "Memory receipts do not support filtering")
 
 	return
 }

--- a/internal/kldrest/memreceipts_test.go
+++ b/internal/kldrest/memreceipts_test.go
@@ -55,7 +55,7 @@ func TestMemReceiptsNoIDFilterImpl(t *testing.T) {
 	}
 	r := newMemoryReceipts(conf)
 
-	_, err := r.GetReceipts(0, 0, []string{"test"}, "t", "t", "t")
+	_, err := r.GetReceipts(0, 0, []string{"test"}, 0, "t", "t")
 	assert.EqualError(err, "Memory receipts do not support filtering")
 
 	return

--- a/internal/kldrest/mongoreceipts.go
+++ b/internal/kldrest/mongoreceipts.go
@@ -16,6 +16,7 @@ package kldrest
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/globalsign/mgo"
@@ -83,12 +84,32 @@ func (m *mongoReceipts) AddReceipt(receipt *map[string]interface{}) error {
 }
 
 // GetReceipts Returns recent receipts with skip & limit
-func (m *mongoReceipts) GetReceipts(skip, limit int, ids []string) (*[]map[string]interface{}, error) {
+func (m *mongoReceipts) GetReceipts(skip, limit int, ids []string, since, from, to string) (*[]map[string]interface{}, error) {
 	filter := bson.M{}
 	if len(ids) > 0 {
 		filter["_id"] = bson.M{
 			"$in": ids,
 		}
+	}
+	if since != "" {
+		var intTime int64
+		if isoTime, err := time.Parse(time.RFC3339Nano, since); err == nil {
+			intTime = isoTime.UnixNano() / int64(time.Millisecond)
+		} else {
+			if intTime, err = strconv.ParseInt(since, 10, 64); err != nil {
+				log.Errorf("since '%s' cannot be parsed as RFC3339 or millisecond timestamp: %s", since, err)
+				return nil, fmt.Errorf("since cannot be parsed as RFC3339 or millisecond timestamp")
+			}
+		}
+		filter["receivedAt"] = bson.M{
+			"$gt": intTime,
+		}
+	}
+	if from != "" {
+		filter["from"] = from
+	}
+	if to != "" {
+		filter["to"] = to
 	}
 	query := m.collection.Find(filter)
 	query.Sort("-receivedAt")

--- a/internal/kldrest/mongoreceipts_test.go
+++ b/internal/kldrest/mongoreceipts_test.go
@@ -241,7 +241,7 @@ func TestMongoReceiptsGetReceiptsOK(t *testing.T) {
 	}
 
 	r.connect()
-	results, err := r.GetReceipts(5, 2, nil)
+	results, err := r.GetReceipts(5, 2, nil, "", "", "")
 	assert.NoError(err)
 	assert.Equal(5, mgoMock.collection.mockQuery.skip)
 	assert.Equal(2, mgoMock.collection.mockQuery.limit)
@@ -271,14 +271,33 @@ func TestMongoReceiptsFilter(t *testing.T) {
 	}
 
 	r.connect()
-	results, err := r.GetReceipts(0, 0, []string{"key1", "key2"})
+	now := time.Now()
+	results, err := r.GetReceipts(0, 0, []string{"key1", "key2"}, now.Format(time.RFC3339Nano), "addr1", "addr2")
 	assert.NoError(err)
 	queryBSON := mgoMock.collection.captureQuery.(bson.M)
 	assert.Equal([]string{"key1", "key2"}, queryBSON["_id"].(bson.M)["$in"])
+	assert.Equal(now.UnixNano()/int64(time.Millisecond), queryBSON["receivedAt"].(bson.M)["$gt"])
+	assert.Equal("addr1", queryBSON["from"])
+	assert.Equal("addr2", queryBSON["to"])
 	assert.Equal(0, mgoMock.collection.mockQuery.skip)
 	assert.Equal(0, mgoMock.collection.mockQuery.limit)
 	assert.Equal("value1", (*results)[0]["key1"])
 	assert.Equal("value2", (*results)[1]["key2"])
+	return
+}
+
+func TestMongoReceiptsFilterBadTime(t *testing.T) {
+	assert := assert.New(t)
+
+	mgoMock := &mockMongo{}
+	r := &mongoReceipts{
+		conf: &MongoDBReceiptStoreConf{},
+		mgo:  mgoMock,
+	}
+
+	r.connect()
+	_, err := r.GetReceipts(0, 0, []string{"key1", "key2"}, "badint", "addr1", "addr2")
+	assert.EqualError(err, "since cannot be parsed as RFC3339 or millisecond timestamp")
 	return
 }
 
@@ -294,7 +313,7 @@ func TestMongoReceiptsGetReceiptsNotFound(t *testing.T) {
 	mgoMock.collection.mockQuery.allErr = mgo.ErrNotFound
 
 	r.connect()
-	results, err := r.GetReceipts(5, 2, nil)
+	results, err := r.GetReceipts(5, 2, nil, "", "", "")
 	assert.NoError(err)
 	assert.Len(*results, 0)
 	return
@@ -312,7 +331,7 @@ func TestMongoReceiptsGetReceiptsError(t *testing.T) {
 	mgoMock.collection.mockQuery.allErr = fmt.Errorf("pop")
 
 	r.connect()
-	_, err := r.GetReceipts(5, 2, nil)
+	_, err := r.GetReceipts(5, 2, nil, "", "", "")
 	assert.EqualError(err, "pop")
 	return
 }

--- a/internal/kldrest/receiptstore.go
+++ b/internal/kldrest/receiptstore.go
@@ -38,7 +38,7 @@ var uuidCharsVerifier, _ = regexp.Compile("^[0-9a-zA-Z-]+$")
 
 // ReceiptStorePersistence interface implemented by persistence layers
 type ReceiptStorePersistence interface {
-	GetReceipts(skip, limit int, ids []string, after, from, to string) (*[]map[string]interface{}, error)
+	GetReceipts(skip, limit int, ids []string, sinceEpochMS int64, from, to string) (*[]map[string]interface{}, error)
 	GetReceipt(requestID string) (*map[string]interface{}, error)
 	AddReceipt(receipt *map[string]interface{}) error
 }
@@ -193,8 +193,25 @@ func (r *receiptStore) getReplies(res http.ResponseWriter, req *http.Request, pa
 		}
 	}
 
+	// Verify since - if specified
+	var sinceEpochMS int64
+	since := req.FormValue("since")
+	if since != "" {
+		if isoTime, err := time.Parse(time.RFC3339Nano, since); err == nil {
+			sinceEpochMS = isoTime.UnixNano() / int64(time.Millisecond)
+		} else {
+			if sinceEpochMS, err = strconv.ParseInt(since, 10, 64); err != nil {
+				log.Errorf("since '%s' cannot be parsed as RFC3339 or millisecond timestamp: %s", since, err)
+				sendRESTError(res, req, fmt.Errorf("since cannot be parsed as RFC3339 or millisecond timestamp"), 400)
+			}
+		}
+	}
+
+	from := req.FormValue("from")
+	to := req.FormValue("to")
+
 	// Call the persistence tier - which must return an empty array when no results (not an error)
-	results, err := r.persistence.GetReceipts(skip, limit, ids, req.FormValue("since"), req.FormValue("from"), req.FormValue("to"))
+	results, err := r.persistence.GetReceipts(skip, limit, ids, sinceEpochMS, from, to)
 	if err != nil {
 		log.Errorf("Error querying replies: %s", err)
 		sendRESTError(res, req, fmt.Errorf("Error querying replies: %s", err), 500)

--- a/internal/kldrest/receiptstore.go
+++ b/internal/kldrest/receiptstore.go
@@ -38,7 +38,7 @@ var uuidCharsVerifier, _ = regexp.Compile("^[0-9a-zA-Z-]+$")
 
 // ReceiptStorePersistence interface implemented by persistence layers
 type ReceiptStorePersistence interface {
-	GetReceipts(skip, limit int, ids []string) (*[]map[string]interface{}, error)
+	GetReceipts(skip, limit int, ids []string, after, from, to string) (*[]map[string]interface{}, error)
 	GetReceipt(requestID string) (*map[string]interface{}, error)
 	AddReceipt(receipt *map[string]interface{}) error
 }
@@ -194,7 +194,7 @@ func (r *receiptStore) getReplies(res http.ResponseWriter, req *http.Request, pa
 	}
 
 	// Call the persistence tier - which must return an empty array when no results (not an error)
-	results, err := r.persistence.GetReceipts(skip, limit, ids)
+	results, err := r.persistence.GetReceipts(skip, limit, ids, req.FormValue("since"), req.FormValue("from"), req.FormValue("to"))
 	if err != nil {
 		log.Errorf("Error querying replies: %s", err)
 		sendRESTError(res, req, fmt.Errorf("Error querying replies: %s", err), 500)

--- a/internal/kldrest/receiptstore_test.go
+++ b/internal/kldrest/receiptstore_test.go
@@ -32,7 +32,7 @@ import (
 
 type mockReceiptErrs struct{ err error }
 
-func (m *mockReceiptErrs) GetReceipts(skip, limit int, ids []string) (*[]map[string]interface{}, error) {
+func (m *mockReceiptErrs) GetReceipts(skip, limit int, ids []string, since, from, to string) (*[]map[string]interface{}, error) {
 	return nil, m.err
 }
 

--- a/internal/kldrest/receiptstore_test.go
+++ b/internal/kldrest/receiptstore_test.go
@@ -32,7 +32,7 @@ import (
 
 type mockReceiptErrs struct{ err error }
 
-func (m *mockReceiptErrs) GetReceipts(skip, limit int, ids []string, since, from, to string) (*[]map[string]interface{}, error) {
+func (m *mockReceiptErrs) GetReceipts(skip, limit int, ids []string, sinceEpochMS int64, from, to string) (*[]map[string]interface{}, error) {
 	return nil, m.err
 }
 
@@ -411,6 +411,57 @@ func TestGetRepliesCustomSkipLimit(t *testing.T) {
 	for i := 0; i < 15; i++ {
 		assert.Equal(fmt.Sprintf("reply%d", 15-i-1), respArr[i]["_id"])
 	}
+}
+
+func TestGetRepliesCustomFiltersISO(t *testing.T) {
+	assert := assert.New(t)
+	_, p, ts := newReceiptsTestServer()
+	defer ts.Close()
+
+	for i := 0; i < 20; i++ {
+		fakeReply := make(map[string]interface{})
+		fakeReply["_id"] = fmt.Sprintf("reply%d", i)
+		p.AddReceipt(&fakeReply)
+	}
+
+	status, resObj, httpErr := testGETObject(ts, "/replies?from=abc&to=bcd&since=2019-01-01T00:00:00Z")
+	assert.NoError(httpErr)
+	assert.Equal(500, status)
+	assert.Equal("Error querying replies: Memory receipts do not support filtering", resObj["error"])
+}
+
+func TestGetRepliesCustomFiltersTS(t *testing.T) {
+	assert := assert.New(t)
+	_, p, ts := newReceiptsTestServer()
+	defer ts.Close()
+
+	for i := 0; i < 20; i++ {
+		fakeReply := make(map[string]interface{})
+		fakeReply["_id"] = fmt.Sprintf("reply%d", i)
+		p.AddReceipt(&fakeReply)
+	}
+
+	status, resObj, httpErr := testGETObject(ts, "/replies?from=abc&to=bcd&since=1580435959")
+	assert.NoError(httpErr)
+	assert.Equal(500, status)
+	assert.Equal("Error querying replies: Memory receipts do not support filtering", resObj["error"])
+}
+
+func TestGetRepliesBadSinceTS(t *testing.T) {
+	assert := assert.New(t)
+	_, p, ts := newReceiptsTestServer()
+	defer ts.Close()
+
+	for i := 0; i < 20; i++ {
+		fakeReply := make(map[string]interface{})
+		fakeReply["_id"] = fmt.Sprintf("reply%d", i)
+		p.AddReceipt(&fakeReply)
+	}
+
+	status, resObj, httpErr := testGETObject(ts, "/replies?from=abc&to=bcd&since=badness")
+	assert.NoError(httpErr)
+	assert.Equal(400, status)
+	assert.Equal("since cannot be parsed as RFC3339 or millisecond timestamp", resObj["error"])
 }
 
 func TestGetRepliesInvalidLimit(t *testing.T) {


### PR DESCRIPTION
- `/replies?from=0x47F58d5b469799b17FC7c9D4B854af08F7e365Fc`
- `/replies?to=0x47F58d5b469799b17FC7c9D4B854af08F7e365Fc`
- `/replies?since=1579128548000` // millisecond epoch timestamp (exclusive greater than)
- `/replies?since=2020-01-15T22:30:00.00Z` // ISO8601 / RFC3339 format