### PR TITLE
Handle in-flight messages during Kafka failover

### DIFF
--- a/internal/kldkafka/client.go
+++ b/internal/kldkafka/client.go
@@ -208,5 +208,8 @@ func (h *saramaKafkaConsumerGroupHandler) Errors() <-chan error {
 }
 
 func (h *saramaKafkaConsumerGroupHandler) MarkOffset(msg *sarama.ConsumerMessage, metadata string) {
-	h.session.MarkMessage(msg, metadata)
+	session := h.session
+	if session != nil {
+		session.MarkMessage(msg, metadata)
+	}
 }


### PR DESCRIPTION
Fix for #43 

From the logs you can see `Consumer session cleanup` happened (due to a Kafka failover event) while there was an in-flight consumer inserting into the receipt store. When it came to acknowledge the message, the session had already been cleaned up.

So we simply need to ignore the request to mark the message - as the session is stale. We will be re-delivered that batch after the consumer session failover completes.