### PR TITLE
Correct plugin loading and Kafka token propagation

### DIFF
--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -53,6 +53,6 @@ func loadSecurityModulePlugin(conf *PluginConfig) error {
 		return fmt.Errorf("Failed to load 'SecurityModule' symbol from '%s': %s", modulePath, err)
 	}
 
-	kldauth.RegisterSecurityModule(smSymbol.(kldplugins.SecurityModule))
+	kldauth.RegisterSecurityModule(*smSymbol.(*kldplugins.SecurityModule))
 	return nil
 }

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -55,7 +55,7 @@ func loadSecurityModulePlugin(conf *PluginConfig) error {
 
 	sm, ok := smSymbol.(kldplugins.SecurityModule)
 	if !ok {
-		return fmt.Errorf("Failed to cast symbol from '%s' to 'kldplugins.SecurityModule'", modulePath)
+		return fmt.Errorf("Failed to cast symbol from '%s' to 'kldplugins.SecurityModule': %v", modulePath, sm)
 	}
 
 	kldauth.RegisterSecurityModule(sm)

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -55,7 +55,7 @@ func loadSecurityModulePlugin(conf *PluginConfig) error {
 
 	sm, ok := smSymbol.(kldplugins.SecurityModule)
 	if !ok {
-		return fmt.Errorf("Failed to cast symbol from '%s' to 'kldplugins.SecurityModule': %v", modulePath, sm)
+		return fmt.Errorf("Failed to cast symbol from '%s' to 'kldplugins.SecurityModule': %v", modulePath, smSymbol)
 	}
 
 	kldauth.RegisterSecurityModule(sm)

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -53,11 +53,6 @@ func loadSecurityModulePlugin(conf *PluginConfig) error {
 		return fmt.Errorf("Failed to load 'SecurityModule' symbol from '%s': %s", modulePath, err)
 	}
 
-	sm, ok := smSymbol.(kldplugins.SecurityModule)
-	if !ok {
-		return fmt.Errorf("Failed to cast symbol from '%s' to 'kldplugins.SecurityModule': %v", modulePath, smSymbol)
-	}
-
-	kldauth.RegisterSecurityModule(sm)
+	kldauth.RegisterSecurityModule(smSymbol.(kldplugins.SecurityModule))
 	return nil
 }

--- a/internal/kldrest/webhooks.go
+++ b/internal/kldrest/webhooks.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/kaleido-io/ethconnect/internal/kldauth"
 	"github.com/kaleido-io/ethconnect/internal/kldcontracts"
 	"github.com/kaleido-io/ethconnect/internal/kldmessages"
 	"github.com/kaleido-io/ethconnect/internal/kldutils"
@@ -130,7 +129,6 @@ func (w *webhooks) processMsg(ctx context.Context, msg map[string]interface{}, a
 	// We always generate the ID. It cannot be set by the user
 	msgID := kldutils.UUIDv4()
 	headers.(map[string]interface{})["id"] = msgID
-	headers.(map[string]interface{})["accessToken"] = kldauth.GetAccessToken(ctx)
 
 	if w.smartContractGW != nil && msgType == kldmessages.MsgTypeDeployContract {
 		var err error

--- a/internal/kldrest/webhookskafka.go
+++ b/internal/kldrest/webhookskafka.go
@@ -134,7 +134,7 @@ func (w *webhooksKafka) sendWebhookMsg(ctx context.Context, key, msgID string, m
 
 	headers, ok := msg["headers"].(map[string]interface{})
 	if ok {
-		headers["accessToken"] = kldauth.GetAccessToken(ctx)
+		headers["token"] = kldauth.GetAccessToken(ctx)
 	}
 
 	// Reseialize back to JSON with the headers

--- a/internal/kldrest/webhookskafka.go
+++ b/internal/kldrest/webhookskafka.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/Shopify/sarama"
+	"github.com/kaleido-io/ethconnect/internal/kldauth"
 	"github.com/kaleido-io/ethconnect/internal/kldkafka"
 	log "github.com/sirupsen/logrus"
 )
@@ -130,6 +131,11 @@ func (w *webhooksKafka) ProducerSuccessLoop(consumer kldkafka.KafkaConsumer, pro
 }
 
 func (w *webhooksKafka) sendWebhookMsg(ctx context.Context, key, msgID string, msg map[string]interface{}, ack bool) (string, int, error) {
+
+	headers, ok := msg["headers"].(map[string]interface{})
+	if ok {
+		headers["accessToken"] = kldauth.GetAccessToken(ctx)
+	}
 
 	// Reseialize back to JSON with the headers
 	payloadToForward, err := json.Marshal(&msg)


### PR DESCRIPTION
The symbol is a pointer, so we need to de-reference it.
Also we get the best error output by letting it panic if it fails to load.