### PR TITLE
Return error when contract registration fails

### DIFF
--- a/internal/kldcontracts/syncdispatcher_test.go
+++ b/internal/kldcontracts/syncdispatcher_test.go
@@ -67,6 +67,10 @@ func (p *mockReplyProcessor) ReplyWithReceipt(receipt kldmessages.ReplyWithHeade
 	p.receipt = receipt
 }
 
+func (p *mockReplyProcessor) ReplyWithReceiptAndError(receipt kldmessages.ReplyWithHeaders, err error) {
+	p.receipt = receipt
+}
+
 func TestDispatchSendTransactionSync(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
- returns tx receipt details (Because the txn succeeded)
- returns a 500 error status with details of the error

Fixes: https://github.com/kaleido-io/ethconnect/issues/39