### PR TITLE
Move token to a Kafka RecordHeader and add receipt store auth plug-point

### DIFF
--- a/internal/kldauth/auth.go
+++ b/internal/kldauth/auth.go
@@ -110,3 +110,27 @@ func AuthEventStreams(ctx context.Context) error {
 	}
 	return nil
 }
+
+// AuthListAsyncReplies authorize the listing or searching of all replies
+func AuthListAsyncReplies(ctx context.Context) error {
+	if securityModule != nil && !IsSystemContext(ctx) {
+		authCtx := GetAuthContext(ctx)
+		if authCtx == nil {
+			return fmt.Errorf("No auth context")
+		}
+		return securityModule.AuthListAsyncReplies(authCtx)
+	}
+	return nil
+}
+
+// AuthReadAsyncReplyByUUID authorize the query of an invidual reply by UUID
+func AuthReadAsyncReplyByUUID(ctx context.Context) error {
+	if securityModule != nil && !IsSystemContext(ctx) {
+		authCtx := GetAuthContext(ctx)
+		if authCtx == nil {
+			return fmt.Errorf("No auth context")
+		}
+		return securityModule.AuthReadAsyncReplyByUUID(authCtx)
+	}
+	return nil
+}

--- a/internal/kldauth/auth_test.go
+++ b/internal/kldauth/auth_test.go
@@ -111,3 +111,39 @@ func TestAuthEventStreams(t *testing.T) {
 	RegisterSecurityModule(nil)
 
 }
+
+func TestAuthListAsyncReplies(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.NoError(AuthListAsyncReplies(context.Background()))
+
+	RegisterSecurityModule(&kldauthtest.TestSecurityModule{})
+
+	assert.EqualError(AuthListAsyncReplies(context.Background()), "No auth context")
+
+	assert.NoError(AuthListAsyncReplies(NewSystemAuthContext()))
+
+	ctx, _ := WithAuthContext(context.Background(), "testat")
+	assert.NoError(AuthListAsyncReplies(ctx))
+
+	RegisterSecurityModule(nil)
+
+}
+
+func TestAuthReadAsyncReplyByUUID(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.NoError(AuthReadAsyncReplyByUUID(context.Background()))
+
+	RegisterSecurityModule(&kldauthtest.TestSecurityModule{})
+
+	assert.EqualError(AuthReadAsyncReplyByUUID(context.Background()), "No auth context")
+
+	assert.NoError(AuthReadAsyncReplyByUUID(NewSystemAuthContext()))
+
+	ctx, _ := WithAuthContext(context.Background(), "testat")
+	assert.NoError(AuthReadAsyncReplyByUUID(ctx))
+
+	RegisterSecurityModule(nil)
+
+}

--- a/internal/kldauth/kldauthtest/testsm.go
+++ b/internal/kldauth/kldauthtest/testsm.go
@@ -59,3 +59,21 @@ func (sm *TestSecurityModule) AuthEventStreams(authCtx interface{}) error {
 	}
 	return fmt.Errorf("badness")
 }
+
+// AuthListAsyncReplies of TEST MODULE returns true if there is an auth context
+func (sm *TestSecurityModule) AuthListAsyncReplies(authCtx interface{}) error {
+	switch authCtx.(type) {
+	case string:
+		return nil
+	}
+	return fmt.Errorf("badness")
+}
+
+// AuthReadAsyncReplyByUUID of TEST MODULE returns true if there is an auth context
+func (sm *TestSecurityModule) AuthReadAsyncReplyByUUID(authCtx interface{}) error {
+	switch authCtx.(type) {
+	case string:
+		return nil
+	}
+	return fmt.Errorf("badness")
+}

--- a/internal/kldkafka/kafkabridge.go
+++ b/internal/kldkafka/kafkabridge.go
@@ -155,8 +155,12 @@ func (k *KafkaBridge) addInflightMsg(msg *sarama.ConsumerMessage, producer Kafka
 		return
 	}
 	headers := &ctx.requestCommon.Headers
-	accessToken := headers.AccessToken
-	headers.AccessToken = ""
+	accessToken := ""
+	for _, header := range msg.Headers {
+		if string(header.Key) == kldmessages.RecordHeaderAccessToken {
+			accessToken = string(header.Value)
+		}
+	}
 	authCtx, err := kldauth.WithAuthContext(context.Background(), accessToken)
 	if err != nil {
 		log.Errorf("Unauthorized: %s - Message=%+v", err, ctx.requestCommon)

--- a/internal/kldkafka/kafkabridge_test.go
+++ b/internal/kldkafka/kafkabridge_test.go
@@ -216,7 +216,6 @@ func TestSingleMessageWithReply(t *testing.T) {
 
 	// Send a minimal test message
 	msg1 := kldmessages.RequestCommon{}
-	msg1.Headers.AccessToken = "testat"
 	msg1.Headers.MsgType = "TestSingleMessageWithReply"
 	msg1Ctx := map[string]interface{}{
 		"some": "data",
@@ -231,6 +230,12 @@ func TestSingleMessageWithReply(t *testing.T) {
 		Partition: 5,
 		Offset:    500,
 		Value:     msg1bytes,
+		Headers: []*sarama.RecordHeader{
+			&sarama.RecordHeader{
+				Key:   []byte(kldmessages.RecordHeaderAccessToken),
+				Value: []byte("testat"),
+			},
+		},
 	}
 
 	// Get the message via the processor

--- a/internal/kldmessages/messages.go
+++ b/internal/kldmessages/messages.go
@@ -35,6 +35,8 @@ const (
 	MsgTypeTransactionSuccess = "TransactionSuccess"
 	// MsgTypeTransactionFailure - a transaction receipt where status is 0
 	MsgTypeTransactionFailure = "TransactionFailure"
+	// RecordHeaderAccessToken - record header name for passing JWT token over messaging
+	RecordHeaderAccessToken = "kld-accesstoken"
 )
 
 // ABIMethod is the web3 form for an individual function
@@ -78,7 +80,6 @@ type RequestCommon struct {
 // RequestHeaders are common to all replies
 type RequestHeaders struct {
 	CommonHeaders
-	AccessToken string `json:"token,omitEmpty"`
 }
 
 // ReplyHeaders are common to all replies

--- a/internal/kldrest/receiptstore_test.go
+++ b/internal/kldrest/receiptstore_test.go
@@ -26,6 +26,8 @@ import (
 	"net/http/httptest"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/kaleido-io/ethconnect/internal/kldauth"
+	"github.com/kaleido-io/ethconnect/internal/kldauth/kldauthtest"
 	"github.com/kaleido-io/ethconnect/internal/kldmessages"
 	"github.com/kaleido-io/ethconnect/internal/kldutils"
 )
@@ -495,4 +497,34 @@ func TestGetRepliesExcessiveLimit(t *testing.T) {
 	assert.NoError(httpErr)
 	assert.Equal(400, status)
 	assert.Equal("Maximum limit is 50", respJSON["error"])
+}
+
+func TestGetRepliesUnauthorized(t *testing.T) {
+	kldauth.RegisterSecurityModule(&kldauthtest.TestSecurityModule{})
+
+	assert := assert.New(t)
+	_, _, ts := newReceiptsTestServer()
+	defer ts.Close()
+
+	status, respJSON, httpErr := testGETObject(ts, "/replies?limit=1000")
+	assert.NoError(httpErr)
+	assert.Equal(401, status)
+	assert.Equal("Unauthorized", respJSON["error"])
+
+	kldauth.RegisterSecurityModule(nil)
+}
+
+func TestGetReplyUnauthorized(t *testing.T) {
+	kldauth.RegisterSecurityModule(&kldauthtest.TestSecurityModule{})
+
+	assert := assert.New(t)
+	_, _, ts := newReceiptsTestServer()
+	defer ts.Close()
+
+	status, respJSON, httpErr := testGETObject(ts, "/reply/12345")
+	assert.NoError(httpErr)
+	assert.Equal(401, status)
+	assert.Equal("Unauthorized", respJSON["error"])
+
+	kldauth.RegisterSecurityModule(nil)
 }

--- a/internal/kldrest/webhookskafka.go
+++ b/internal/kldrest/webhookskafka.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/kaleido-io/ethconnect/internal/kldauth"
 	"github.com/kaleido-io/ethconnect/internal/kldkafka"
+	"github.com/kaleido-io/ethconnect/internal/kldmessages"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -132,11 +133,6 @@ func (w *webhooksKafka) ProducerSuccessLoop(consumer kldkafka.KafkaConsumer, pro
 
 func (w *webhooksKafka) sendWebhookMsg(ctx context.Context, key, msgID string, msg map[string]interface{}, ack bool) (string, int, error) {
 
-	headers, ok := msg["headers"].(map[string]interface{})
-	if ok {
-		headers["token"] = kldauth.GetAccessToken(ctx)
-	}
-
 	// Reseialize back to JSON with the headers
 	payloadToForward, err := json.Marshal(&msg)
 	if err != nil {
@@ -152,6 +148,15 @@ func (w *webhooksKafka) sendWebhookMsg(ctx context.Context, key, msgID string, m
 		Key:      sarama.StringEncoder(key),
 		Value:    sarama.ByteEncoder(payloadToForward),
 		Metadata: msgID,
+	}
+	accessToken := kldauth.GetAccessToken(ctx)
+	if accessToken != "" {
+		sentMsg.Headers = []sarama.RecordHeader{
+			sarama.RecordHeader{
+				Key:   []byte(kldmessages.RecordHeaderAccessToken),
+				Value: []byte(accessToken),
+			},
+		}
 	}
 	w.kafka.Producer().Input() <- sentMsg
 

--- a/pkg/kldplugins/securitymodule.go
+++ b/pkg/kldplugins/securitymodule.go
@@ -31,4 +31,8 @@ type SecurityModule interface {
 	AuthRPCSubscribe(authCtx interface{}, namespace string, channel interface{}, args ...interface{}) error
 	// AuthEventStreams - Authorization plugpoint for event management system (single permission currently - evolution likely as requirements evolve)
 	AuthEventStreams(authCtx interface{}) error
+	// AuthListAsyncReplies - Authorization plugpoint for listing replies in the reply store (containing receipts and/or errors)
+	AuthListAsyncReplies(authCtx interface{}) error
+	// AuthReadAsyncReplyByUUID - Authorization plugpoint for getting an individual reply by UUID (containing an individual receipt/error)
+	AuthReadAsyncReplyByUUID(authCtx interface{}) error
 }


### PR DESCRIPTION
Serializing into the payload that's passed through the code seems less correct, than exchanging directly from the Go context to/from the Kafka `RecordHeader`