### PR TITLE
Handle 0x prefix in contract addr in URL

### DIFF
--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -341,7 +341,8 @@ func (g *smartContractGW) resolveContractAddr(registeredName string) (string, er
 	return info.Address, nil
 }
 
-func (g *smartContractGW) loadDeployMsgForInstance(addrHexNo0x string) (*kldmessages.DeployContract, *contractInfo, error) {
+func (g *smartContractGW) loadDeployMsgForInstance(addrHex string) (*kldmessages.DeployContract, *contractInfo, error) {
+	addrHexNo0x := strings.TrimPrefix(strings.ToLower(addrHex), "0x")
 	info, exists := g.contractIndex[addrHexNo0x]
 	if !exists {
 		return nil, nil, fmt.Errorf("No contract instance registered with address %s", addrHexNo0x)

--- a/internal/kldcontracts/smartcontractgw_test.go
+++ b/internal/kldcontracts/smartcontractgw_test.go
@@ -188,7 +188,7 @@ func TestPreDeployCompileAndPostDeploy(t *testing.T) {
 	assert.Equal("0123456789abcdef0123456789abcdef01234567", body[0].Address)
 
 	// Check we can get it back over REST
-	req = httptest.NewRequest("GET", "/contracts/0123456789abcdef0123456789abcdef01234567", bytes.NewReader([]byte{}))
+	req = httptest.NewRequest("GET", "/contracts/0x0123456789abcdef0123456789abcdef01234567", bytes.NewReader([]byte{}))
 	res = httptest.NewRecorder()
 	router.ServeHTTP(res, req)
 	assert.Equal(200, res.Result().StatusCode)
@@ -203,6 +203,15 @@ func TestPreDeployCompileAndPostDeploy(t *testing.T) {
 	router.ServeHTTP(res, req)
 	assert.Equal(200, res.Result().StatusCode)
 	var swagger spec.Swagger
+	err = json.NewDecoder(res.Body).Decode(&swagger)
+	assert.NoError(err)
+	assert.Equal("SimpleEvents", swagger.Info.Title)
+
+	// Check we can get the full contract swagger back over REST with contract addr that includes 0x prefix
+	req = httptest.NewRequest("GET", "/contracts/0x0123456789abcdef0123456789abcdef01234567?swagger", bytes.NewReader([]byte{}))
+	res = httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+	assert.Equal(200, res.Result().StatusCode)
 	err = json.NewDecoder(res.Body).Decode(&swagger)
 	assert.NoError(err)
 	assert.Equal("SimpleEvents", swagger.Info.Title)


### PR DESCRIPTION
Before resolving the contract address to a deployed contract instance
via the internal cache, strip out any leading `0x` prefix.

Fixes https://github.com/kaleido-io/ethconnect/issues/54