### PR TITLE
Add LogIndex to event data

### DIFF
--- a/internal/kldevents/logprocessor.go
+++ b/internal/kldevents/logprocessor.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -45,6 +46,7 @@ type eventData struct {
 	Data             map[string]interface{} `json:"data"`
 	SubID            string                 `json:"subId"`
 	Signature        string                 `json:"signature"`
+	LogIndex         string                 `json:"logIndex"`
 	// Used for callback handling
 	batchComplete func(*eventData)
 }
@@ -90,7 +92,7 @@ func (lp *logProcessor) initBlockHWM(intVal *big.Int) {
 	lp.hwnSync.Unlock()
 }
 
-func (lp *logProcessor) processLogEntry(subInfo string, entry *logEntry) (err error) {
+func (lp *logProcessor) processLogEntry(subInfo string, entry *logEntry, idx int) (err error) {
 
 	var data []byte
 	if strings.HasPrefix(entry.Data, "0x") {
@@ -108,6 +110,7 @@ func (lp *logProcessor) processLogEntry(subInfo string, entry *logEntry) (err er
 		Signature:        lp.event.Sig(),
 		Data:             make(map[string]interface{}),
 		SubID:            lp.subID,
+		LogIndex:         strconv.Itoa(idx),
 		batchComplete:    lp.batchComplete,
 	}
 	topicIdx := 0

--- a/internal/kldevents/logprocessor_test.go
+++ b/internal/kldevents/logprocessor_test.go
@@ -71,7 +71,7 @@ func TestProcessLogEntryNillAndTooFewFields(t *testing.T) {
 	}
 	err := lp.processLogEntry("ut", &logEntry{
 		Topics: []*kldbind.Hash{nil},
-	})
+	}, 2)
 
 	assert.EqualError(err, "ut: Ran out of topics for indexed fields at field 1 of event ( indexed one,  indexed two)")
 }
@@ -96,7 +96,7 @@ func TestProcessLogBadRLPData(t *testing.T) {
 	}
 	err := lp.processLogEntry(t.Name(), &logEntry{
 		Data: "0x00",
-	})
+	}, 0)
 
 	assert.Regexp("Failed to parse RLP data from event", err.Error())
 }

--- a/internal/kldevents/subscription.go
+++ b/internal/kldevents/subscription.go
@@ -178,8 +178,8 @@ func (s *subscription) processNewEvents(ctx context.Context) error {
 		// Only log if we received at least one event
 		log.Debugf("%s: received %d events (%s)", s.logName, len(logs), rpcMethod)
 	}
-	for _, logEntry := range logs {
-		if err := s.lp.processLogEntry(s.logName, logEntry); err != nil {
+	for idx, logEntry := range logs {
+		if err := s.lp.processLogEntry(s.logName, logEntry, idx); err != nil {
 			log.Errorf("Failed to processs event: %s", err)
 		}
 	}


### PR DESCRIPTION
to disambiguate logs for any post-processing of logs in a webhook, the
current published fields do not suffice when multiple events of the same
type are emitted from a method in a smart contract. Adding LogIndex
ensures that different events can be disambiguated by constructing a
hash of the fields in webhook