### PR TITLE
Standardize errors

### DIFF
--- a/cmd/ethconnect.go
+++ b/cmd/ethconnect.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/icza/dyno"
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	"github.com/kaleido-io/ethconnect/internal/kldkafka"
 	"github.com/kaleido-io/ethconnect/internal/kldrest"
 	"github.com/kaleido-io/ethconnect/internal/kldutils"
@@ -97,7 +98,7 @@ func initServer() (serverCmd *cobra.Command) {
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) (err error) {
 			if serverCmdConfig.Filename == "" {
-				err = fmt.Errorf("No YAML configuration filename specified")
+				err = klderrors.Errorf(klderrors.ConfigNoYAML)
 				return
 			}
 			return
@@ -115,14 +116,14 @@ func initServer() (serverCmd *cobra.Command) {
 func readServerConfig() (serverConfig *ServerConfig, err error) {
 	confBytes, err := ioutil.ReadFile(serverCmdConfig.Filename)
 	if err != nil {
-		err = fmt.Errorf("Failed to read %s: %s", serverCmdConfig.Filename, err)
+		err = klderrors.Errorf(klderrors.ConfigFileReadFailed, serverCmdConfig.Filename, err)
 		return
 	}
 	if strings.ToLower(serverCmdConfig.Type) == "yaml" {
 		// Convert to JSON first
 		yamlGenericPayload := make(map[interface{}]interface{})
 		if err = yaml.Unmarshal(confBytes, &yamlGenericPayload); err != nil {
-			err = fmt.Errorf("Unable to parse %s as YAML: %s", serverCmdConfig.Filename, err)
+			err = klderrors.Errorf(klderrors.ConfigYAMLParseFile, serverCmdConfig.Filename, err)
 			return
 		}
 		genericPayload := dyno.ConvertMapI2MapS(yamlGenericPayload).(map[string]interface{})
@@ -132,7 +133,7 @@ func readServerConfig() (serverConfig *ServerConfig, err error) {
 	serverConfig = &ServerConfig{}
 	err = json.Unmarshal(confBytes, serverConfig)
 	if err != nil {
-		err = fmt.Errorf("Failed to process YAML config from %s: %s", serverCmdConfig.Filename, err)
+		err = klderrors.Errorf(klderrors.ConfigYAMLPostParseFile, serverCmdConfig.Filename, err)
 		return
 	}
 

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -15,10 +15,10 @@
 package cmd
 
 import (
-	"fmt"
 	"plugin"
 
 	"github.com/kaleido-io/ethconnect/internal/kldauth"
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	"github.com/kaleido-io/ethconnect/pkg/kldplugins"
 	log "github.com/sirupsen/logrus"
 )
@@ -45,12 +45,12 @@ func loadSecurityModulePlugin(conf *PluginConfig) error {
 	log.Debugf("Loading SecurityModule plugin '%s'", modulePath)
 	smPlugin, err := plugin.Open(modulePath)
 	if err != nil {
-		return fmt.Errorf("Failed to load plugin: %s", err)
+		return klderrors.Errorf(klderrors.SecurityModulePluginLoad, err)
 	}
 
 	smSymbol, err := smPlugin.Lookup("SecurityModule")
 	if err != nil || smSymbol == nil {
-		return fmt.Errorf("Failed to load 'SecurityModule' symbol from '%s': %s", modulePath, err)
+		return klderrors.Errorf(klderrors.SecurityModulePluginSymbol, modulePath, err)
 	}
 
 	kldauth.RegisterSecurityModule(*smSymbol.(*kldplugins.SecurityModule))

--- a/go.mod
+++ b/go.mod
@@ -34,11 +34,12 @@ require (
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/nicksnyder/go-i18n/v2 v2.0.3
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/nwaples/rardecode v1.0.0 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pierrec/lz4 v2.3.0+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563 // indirect
 	github.com/rjeczalik/notify v0.9.2 // indirect
 	github.com/rs/cors v1.7.0 // indirect
@@ -57,6 +58,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d // indirect
 	golang.org/x/net v0.0.0-20191112182307-2180aed22343 // indirect
 	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 // indirect
+	golang.org/x/text v0.3.2
 	gopkg.in/jcmturner/gokrb5.v7 v7.3.0 // indirect
 	gopkg.in/yaml.v2 v2.2.5
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxB
 github.com/Azure/go-autorest/autorest/mocks v0.3.0/go.mod h1:a8FDP3DYzQ4RYfVAxAN3SVSiiO77gL2j2ronKKP0syM=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
+github.com/BurntSushi/toml v0.3.0/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
@@ -228,6 +229,9 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
+github.com/nicksnyder/go-i18n v2.0.3+incompatible h1:XCCaWsCoy4KlWkhOr+63dkv6oJmitJ573uJqDBAiFiQ=
+github.com/nicksnyder/go-i18n/v2 v2.0.3 h1:ks/JkQiOEhhuF6jpNvx+Wih1NIiXzUnZeZVnJuI8R8M=
+github.com/nicksnyder/go-i18n/v2 v2.0.3/go.mod h1:oDab7q8XCYMRlcrBnaY/7B1eOectbvj6B1UPBT+p5jo=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/nwaples/rardecode v1.0.0 h1:r7vGuS5akxOnR4JQSkko62RJ1ReCMXxQRPtxsiFMBOs=
@@ -350,6 +354,7 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
+golang.org/x/crypto v0.0.0-20190506204251-e1dfcc566284/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708 h1:pXVtWnwHkrWD9ru3sDxY/qFK/bfc0egRovX91EjWjf4=
 golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -361,6 +366,7 @@ golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -384,6 +390,7 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -399,6 +406,7 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190912185636-87d9f09c5d89/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/internal/kldauth/auth.go
+++ b/internal/kldauth/auth.go
@@ -16,8 +16,8 @@ package kldauth
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	"github.com/kaleido-io/ethconnect/pkg/kldplugins"
 )
 
@@ -80,7 +80,7 @@ func AuthRPC(ctx context.Context, method string, args ...interface{}) error {
 	if securityModule != nil && !IsSystemContext(ctx) {
 		authCtx := GetAuthContext(ctx)
 		if authCtx == nil {
-			return fmt.Errorf("No auth context")
+			return klderrors.Errorf(klderrors.SecurityModuleNoAuthContext)
 		}
 		return securityModule.AuthRPC(authCtx, method, args...)
 	}
@@ -92,7 +92,7 @@ func AuthRPCSubscribe(ctx context.Context, namespace string, channel interface{}
 	if securityModule != nil && !IsSystemContext(ctx) {
 		authCtx := GetAuthContext(ctx)
 		if authCtx == nil {
-			return fmt.Errorf("No auth context")
+			return klderrors.Errorf(klderrors.SecurityModuleNoAuthContext)
 		}
 		return securityModule.AuthRPCSubscribe(authCtx, namespace, channel, args...)
 	}
@@ -104,7 +104,7 @@ func AuthEventStreams(ctx context.Context) error {
 	if securityModule != nil && !IsSystemContext(ctx) {
 		authCtx := GetAuthContext(ctx)
 		if authCtx == nil {
-			return fmt.Errorf("No auth context")
+			return klderrors.Errorf(klderrors.SecurityModuleNoAuthContext)
 		}
 		return securityModule.AuthEventStreams(authCtx)
 	}
@@ -116,7 +116,7 @@ func AuthListAsyncReplies(ctx context.Context) error {
 	if securityModule != nil && !IsSystemContext(ctx) {
 		authCtx := GetAuthContext(ctx)
 		if authCtx == nil {
-			return fmt.Errorf("No auth context")
+			return klderrors.Errorf(klderrors.SecurityModuleNoAuthContext)
 		}
 		return securityModule.AuthListAsyncReplies(authCtx)
 	}
@@ -128,7 +128,7 @@ func AuthReadAsyncReplyByUUID(ctx context.Context) error {
 	if securityModule != nil && !IsSystemContext(ctx) {
 		authCtx := GetAuthContext(ctx)
 		if authCtx == nil {
-			return fmt.Errorf("No auth context")
+			return klderrors.Errorf(klderrors.SecurityModuleNoAuthContext)
 		}
 		return securityModule.AuthReadAsyncReplyByUUID(authCtx)
 	}

--- a/internal/kldcontracts/remoteregistry.go
+++ b/internal/kldcontracts/remoteregistry.go
@@ -148,7 +148,7 @@ func (rr *remoteRegistry) loadFactoryFromURL(baseURL, ns, lookupStr string) (*de
 	err = json.Unmarshal([]byte(abiString), &abi)
 	if err != nil {
 		log.Errorf("GET %s <-- !Failed to decode ABI: %s\n%s", queryURL, err, abiString)
-		return nil, klderrors.Errorf(klderrors.RemoteRegistryLookupDecodeABIFailed)
+		return nil, klderrors.Errorf(klderrors.RemoteRegistryLookupGenericProcessingFailed)
 	}
 	devdoc, err := rr.hr.GetResponseString(jsonRes, rr.conf.PropNames.Devdoc, true)
 	if err != nil {
@@ -161,7 +161,7 @@ func (rr *remoteRegistry) loadFactoryFromURL(baseURL, ns, lookupStr string) (*de
 	var bytecode []byte
 	if bytecode, err = hex.DecodeString(strings.TrimPrefix(bytecodeStr, "0x")); err != nil {
 		log.Errorf("GET %s <-- !Failed to parse bytecode: %s\n%s", queryURL, err, bytecodeStr)
-		return nil, klderrors.Errorf(klderrors.RemoteRegistryLookupDecodeBytecodeFailed)
+		return nil, klderrors.Errorf(klderrors.RemoteRegistryLookupGenericProcessingFailed)
 	}
 	addr, _ := rr.hr.GetResponseString(jsonRes, rr.conf.PropNames.Address, false)
 	msg = &deployContractWithAddress{

--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -1037,7 +1037,7 @@ func (g *smartContractGW) addABI(res http.ResponseWriter, req *http.Request, par
 
 	compiled, err := kldeth.ProcessCompiled(preCompiled, req.FormValue("contract"), false)
 	if err != nil {
-		g.gatewayErrReply(res, req, klderrors.Errorf(klderrors.RESTGatewayCompileContractPostcompileFailed, err), 400)
+		g.gatewayErrReply(res, req, klderrors.Errorf(klderrors.RESTGatewayCompileContractPostCompileFailed, err), 400)
 		return
 	}
 

--- a/internal/kldcontracts/syncdispatcher.go
+++ b/internal/kldcontracts/syncdispatcher.go
@@ -20,9 +20,11 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	"github.com/kaleido-io/ethconnect/internal/kldmessages"
 	"github.com/kaleido-io/ethconnect/internal/kldtx"
 	"github.com/kaleido-io/ethconnect/internal/kldutils"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -65,7 +67,7 @@ func (t *syncTxInflight) Unmarshal(msg interface{}) error {
 	}
 	if reflect.TypeOf(msg) != reflect.TypeOf(retMsg) {
 		log.Errorf("Type mismatch: %s != %s", reflect.TypeOf(msg), reflect.TypeOf(retMsg))
-		return fmt.Errorf("Unexpected condition (message types do not match when processing)")
+		return klderrors.Errorf(klderrors.RESTGatewaySyncMsgTypeMismatch)
 	}
 	reflect.ValueOf(msg).Elem().Set(reflect.ValueOf(retMsg).Elem())
 	return nil
@@ -76,7 +78,7 @@ func (t *syncTxInflight) SendErrorReply(status int, err error) {
 }
 
 func (t *syncTxInflight) SendErrorReplyWithTX(status int, err error, txHash string) {
-	t.SendErrorReply(status, fmt.Errorf("TX %s: %s", txHash, err))
+	t.SendErrorReply(status, klderrors.Errorf(klderrors.RESTGatewaySyncWrapErrorWithTXDetail, txHash, err))
 }
 
 func (t *syncTxInflight) Reply(replyMessage kldmessages.ReplyWithHeaders) {

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -37,7 +37,7 @@ const (
 	// CompilerVerionNotFound the runtime context of ethconnect has not been configured with a compiler for the requested version
 	CompilerVersionNotFound = "Could not find a configured compiler for requested Solidity major version %s.%s"
 	// CompilerVerionBadRequest the user requested a bad semver
-	CompilerVerionBadRequest = "Invalid Solidity version requested for compiler. Ensure the string starts with two dot separated numbers, such as 0.5"
+	CompilerVersionBadRequest = "Invalid Solidity version requested for compiler. Ensure the string starts with two dot separated numbers, such as 0.5"
 	// CompilerFailedSolc compilation failure output from solc
 	CompilerFailedSolc = "Solidity compilation failed: solc: %v\n%s"
 	// CompilerOutputMissingContract the output from the compiler does not include the requested contract

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -200,10 +200,8 @@ const (
 	RemoteRegistryLookupGatewayNotFound = "Gateway not found"
 	// RemoteRegistryLookupInstanceNotFound did not find the requested ID in the remote registry for a contract instance
 	RemoteRegistryLookupInstanceNotFound = "Instance not found"
-	// RemoteRegistryLookupDecodeABIFailed couldn't parse the ABI in the response
-	RemoteRegistryLookupDecodeABIFailed = "Error processing contract registry response"
-	// RemoteRegistryLookupDecodeBytecodeFailed couldn't parse the ABI in the response
-	RemoteRegistryLookupDecodeBytecodeFailed = "Error processing contract registry response"
+	// RemoteRegistryLookupGenericProcessingFailed we don't return the full original error over the REST API after logging
+	RemoteRegistryLookupGenericProcessingFailed = "Error processing contract registry response"
 
 	// RESTGatewayGatewayNotFound the gateway REST API interface (the 'factory' / ABI generic interface) was not found
 	RESTGatewayGatewayNotFound = "Gateway not found"

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -241,7 +241,7 @@ const (
 	// RESTGatewayCompileContractCompileFailed failed to perform compile
 	RESTGatewayCompileContractCompileFailed = "Failed to compile solidity: %s"
 	// RESTGatewayCompileContractPostcompileFailed failed to process output of compilation
-	RESTGatewayCompileContractPostcompileFailed = "Failed to process solidity: %s"
+	RESTGatewayCompileContractPostCompileFailed = "Failed to process solidity: %s"
 	// RESTGatewayCompileContractExtractedReadFailed failed to read extracted contents of uploaded data
 	RESTGatewayCompileContractExtractedReadFailed = "Failed to read extracted multi-part form data"
 	// RESTGatewayCompileContractNoSOL failed to find any solidity files in uploaded data

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -35,7 +35,7 @@ const (
 	// ConfigFileReadFailed failed to read the server config file
 	ConfigFileReadFailed = "Failed to read %s: %s"
 	// CompilerVerionNotFound the runtime context of ethconnect has not been configured with a compiler for the requested version
-	CompilerVerionNotFound = "Could not find a configured compiler for requested Solidity major version %s.%s"
+	CompilerVersionNotFound = "Could not find a configured compiler for requested Solidity major version %s.%s"
 	// CompilerVerionBadRequest the user requested a bad semver
 	CompilerVerionBadRequest = "Invalid Solidity version requested for compiler. Ensure the string starts with two dot separated numbers, such as 0.5"
 	// CompilerFailedSolc compilation failure output from solc

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -133,7 +133,7 @@ const (
 	// HDWalletSigningBadData we got a response, but not with the correct fields
 	HDWalletSigningBadData = "Unexpected response from HDWallet"
 	// HDWalletSigningNoConfog we had a request for HD Wallet signing, but we don't have the required config
-	HDWalletSigningNoConfog = "No HD Wallet Configuration"
+	HDWalletSigningNoConfig = "No HD Wallet Configuration"
 
 	// HelperStrToAddressRequiredField re-usable error for missing fields
 	HelperStrToAddressRequiredField = "'%s' must be supplied"

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Kaleido
+// Copyright 2019,2020 Kaleido
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -1,0 +1,422 @@
+// Copyright 2019 Kaleido
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package klderrors
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// ErrorID enumerates all errors in ethconnect.
+type ErrorID string
+
+const (
+
+	// AddressBookLookupBadURL we got back a bad URL from the remote address book after our REST call
+	AddressBookLookupBadURL = "Invalid URL obtained for address"
+	// AddressBookLookupBadHostsFile we have a custom hosts file for DNS resolution, but it cannot be processed
+	AddressBookLookupBadHostsFile = "Configuration problem (hosts file)"
+	// AddressBookLookupNotFound remote addressbook says no
+	AddressBookLookupNotFound = "Unknown address"
+
+	// ConfigFileReadFailed failed to read the server config file
+	ConfigFileReadFailed = "Failed to read %s: %s"
+	// CompilerVerionNotFound the runtime context of ethconnect has not been configured with a compiler for the requested version
+	CompilerVerionNotFound = "Could not find a configured compiler for requested Solidity major version %s.%s"
+	// CompilerVerionBadRequest the user requested a bad semver
+	CompilerVerionBadRequest = "Invalid Solidity version requested for compiler. Ensure the string starts with two dot separated numbers, such as 0.5"
+	// CompilerFailedSolc compilation failure output from solc
+	CompilerFailedSolc = "Solidity compilation failed: solc: %v\n%s"
+	// CompilerOutputMissingContract the output from the compiler does not include the requested contract
+	CompilerOutputMissingContract = "Contract '%s' not found in Solidity source: %s"
+	// CompilerOutputMultipleContracts need to select one
+	CompilerOutputMultipleContracts = "More than one contract in Solidity file, please set one to call: %s"
+	// CompilerBytecodeInvalid hex output from compiler could not be parsed
+	CompilerBytecodeInvalid = "Decoding bytecode: %s"
+	// CompilerBytecodeEmpty null result from succcessful compile in solc
+	CompilerBytecodeEmpty = "Specified contract compiled ok, but did not result in any bytecode: %s"
+	// CompilerABISerialize could not serialize the ABI output from solc
+	CompilerABISerialize = "Serializing ABI: %s"
+	// CompilerABIReRead could not re-read serialized output after writing the ABI
+	CompilerABIReRead = "Parsing ABI: %s"
+	// CompilerSerializeDevDocs could not serialize the dev docs output from solc
+	CompilerSerializeDevDocs = "Serializing DevDoc: %s"
+	// ConfigNoRPC missing config for JSON/RPC
+	ConfigNoRPC = "No JSON/RPC URL set for ethereum node"
+	// ConfigKafkaMissingOutputTopic response topic missing
+	ConfigKafkaMissingOutputTopic = "No output topic specified for bridge to send events to"
+	// ConfigKafkaMissingInputTopic request topic missing
+	ConfigKafkaMissingInputTopic = "No input topic specified for bridge to listen to"
+	// ConfigKafkaMissingConsumerGroup consumer group missing
+	ConfigKafkaMissingConsumerGroup = "No consumer group specified"
+	// ConfigKafkaMissingBadSASL problem with SASL config
+	ConfigKafkaMissingBadSASL = "Username and Password must both be provided for SASL"
+	// ConfigKafkaMissingBrokers missing/empty brokers
+	ConfigKafkaMissingBrokers = "No Kafka brokers configured"
+	// ConfigRESTGatewayRequiredReceiptStore need to enable params for REST Gatewya
+	ConfigRESTGatewayRequiredReceiptStore = "MongoDB URL, Database and Collection name must be specified to enable the receipt store"
+	// ConfigRESTGatewayRequiredRPC and RPC stuff
+	ConfigRESTGatewayRequiredRPC = "RPC URL and Storage Path must be supplied to enable the Open API REST Gateway"
+	// ConfigWebhooksDirectRPC for webhooks direct
+	ConfigWebhooksDirectRPC = "No JSON/RPC URL set for ethereum node"
+	// ConfigTLSCertOrKey incomplete TLS config
+	ConfigTLSCertOrKey = "Client private key and certificate must both be provided for mutual auth"
+
+	// ConfigNoYAML missing configuration file on server start
+	ConfigNoYAML = "No YAML configuration filename specified"
+	// ConfigYAMLParseFile failed to parse YAML during server startup
+	ConfigYAMLParseFile = "Unable to parse %s as YAML: %s"
+	// ConfigYAMLPostParseFile failed to process YAML as JSON after parsing
+	ConfigYAMLPostParseFile = "Failed to process YAML config from %s: %s"
+
+	// DeployTransactionMissingCode a DeployTransaction message, without code to deploy
+	DeployTransactionMissingCode = "Missing Compiled Code + ABI, or Solidity"
+
+	// EventStreamsDBLoad failed to init DB
+	EventStreamsDBLoad = "Failed to open DB at %s: %s"
+	// EventStreamsNoID attempt to create an event stream/sub without an ID
+	EventStreamsNoID = "No ID"
+	// EventStreamsWebhookNoURL attempt to create a Webhook event stream without a URL
+	EventStreamsWebhookNoURL = "Must specify webhook.url for action type 'webhook'"
+	// EventStreamsWebhookInvalidURL attempt to create a Webhook event stream with an invalid URL
+	EventStreamsWebhookInvalidURL = "Invalid URL in webhook action"
+	// EventStreamsWebhookInvalidActionType unknown action type
+	EventStreamsWebhookInvalidActionType = "Unknown action type '%s'"
+	// EventStreamsWebhookResumeActive resume when already resumed
+	EventStreamsWebhookResumeActive = "Event processor is already active. Suspending:%t"
+	// EventStreamsWebhookProhibitedAddress some IP ranges can be restricted
+	EventStreamsWebhookProhibitedAddress = "Cannot send Webhook POST to address: %s"
+	// EventStreamsWebhookFailedHTTPStatus server at the other end of a webhook returned a non-OK response
+	EventStreamsWebhookFailedHTTPStatus = "%s: Failed with status=%d"
+	// EventStreamsSubscribeBadBlock the starting block for a subscription request is invalid
+	EventStreamsSubscribeBadBlock = "FromBlock cannot be parsed as a BigInt"
+	// EventStreamsSubscribeStoreFailed problem saving a subscription to our DB
+	EventStreamsSubscribeStoreFailed = "Failed to store subscription: %s"
+	// EventStreamsSubscribeNoEvent missing event
+	EventStreamsSubscribeNoEvent = "Solidity event name must be specified"
+	// EventStreamsSubscriptionNotFound sub not found
+	EventStreamsSubscriptionNotFound = "Subscription with ID '%s' not found"
+	// EventStreamsCreateStreamStoreFailed problem saving a subscription to our DB
+	EventStreamsCreateStreamStoreFailed = "Failed to store stream: %s"
+	// EventStreamsStreamNotFound stream not found
+	EventStreamsStreamNotFound = "Stream with ID '%s' not found"
+	// EventStreamsLogDecode problem decoding the logs for an event emitted on the chain
+	EventStreamsLogDecode = "%s: Failed to decode data: %s"
+	// EventStreamsLogDecodeInsufficientTopics ran out of topics according to the indexed fields described on the ABI event
+	EventStreamsLogDecodeInsufficientTopics = "%s: Ran out of topics for indexed fields at field %d of %+v"
+	// EventStreamsLogDecodeData RLP decoding of the data section of the logs failed
+	EventStreamsLogDecodeData = "%s: Failed to parse RLP data from event: %s"
+
+	// KakfaProducerConfirmMsgUnknown we received a confirmation callback, but we aren't expecting it
+	KakfaProducerConfirmMsgUnknown = "Received confirmation for message not in in-flight map: %s"
+
+	// KVStoreDBLoad failed to init DB
+	KVStoreDBLoad = "Failed to open DB at %s: %s"
+	// KVStoreMemFilteringUnsupported memory db is really just for testing. No filtering support
+	KVStoreMemFilteringUnsupported = "Memory receipts do not support filtering"
+
+	// HDWalletSigningFailed problem returned from remote HDWallet API
+	HDWalletSigningFailed = "HDWallet signing failed"
+	// HDWalletSigningBadData we got a response, but not with the correct fields
+	HDWalletSigningBadData = "Unexpected response from HDWallet"
+	// HDWalletSigningNoConfog we had a request for HD Wallet signing, but we don't have the required config
+	HDWalletSigningNoConfog = "No HD Wallet Configuration"
+
+	// HelperStrToAddressRequiredField re-usable error for missing fields
+	HelperStrToAddressRequiredField = "'%s' must be supplied"
+	// HelperStrToAddressBadAddress re-usable error for bad address
+	HelperStrToAddressBadAddress = "Supplied value for '%s' is not a valid hex address"
+	// HelperYAMLorJSONPayloadTooLarge input message too large
+	HelperYAMLorJSONPayloadTooLarge = "Message exceeds maximum allowable size"
+	// HelperYAMLorJSONPayloadReadFailed failed to read input
+	HelperYAMLorJSONPayloadReadFailed = "Unable to read input data: %s"
+	// HelperYAMLorJSONPayloadParseFailed input message got error parsing
+	HelperYAMLorJSONPayloadParseFailed = "Unable to parse as YAML or JSON: %s"
+
+	// HTTPRequesterSerializeFailed common HTTP request utility for extensions, failed to serialize request
+	HTTPRequesterSerializeFailed = "Failed to serialize request payload: %s"
+	// HTTPRequesterNonStatusError common HTTP request utility for extensions, got an error sending a request
+	HTTPRequesterNonStatusError = "Error querying %s"
+	// HTTPRequesterStatusErrorNoData common HTTP request utility for extensions, got a status code, but couldn't deserialize payload
+	HTTPRequesterStatusErrorNoData = "Could not process %s [%d] response"
+	// HTTPRequesterStatusErrorWithData common HTTP request utility for extensions, got a non-ok status code with JSON errorMessage
+	HTTPRequesterStatusErrorWithData = "%s returned [%d]: %s"
+	// HTTPRequesterStatusError common HTTP request utility for extensions, got a non-ok status code
+	HTTPRequesterStatusError = "Error querying %s"
+	// HTTPRequesterResponseMissingField common HTTP request utility for extensions, missing expected field in response
+	HTTPRequesterResponseMissingField = "'%s' missing in %s response"
+	// HTTPRequesterResponseNonStringField common HTTP request utility for extensions, expected string for field in response
+	HTTPRequesterResponseNonStringField = "'%s' not a string in %s response"
+	// HTTPRequesterResponseNullField common HTTP request utility for extensions, expected non-empty response field
+	HTTPRequesterResponseNullField = "'%s' empty (or null) in %s response"
+
+	// ReceiptStoreDisabled not configured
+	ReceiptStoreDisabled = "Receipt store not enabled"
+	// ReceiptStoreDBLoad failed to init DB
+	ReceiptStoreDBLoad = "Failed to open DB at %s: %s"
+	// ReceiptStoreMongoDBConnect couldn't connect to MongoDB
+	ReceiptStoreMongoDBConnect = "Unable to connect to MongoDB: %s"
+	// ReceiptStoreMongoDBIndex couldn't create MongoDB index
+	ReceiptStoreMongoDBIndex = "Unable to create index: %s"
+	// ReceiptStoreSerializeResponse problem sending a receipt stored back over the REST API
+	ReceiptStoreSerializeResponse = "Error serializing response"
+	// ReceiptStoreInvalidRequestID bad ID query
+	ReceiptStoreInvalidRequestID = "Invalid 'id' query parameter"
+	// ReceiptStoreInvalidRequestMaxLimit bad limit over max
+	ReceiptStoreInvalidRequestMaxLimit = "Maximum limit is %d"
+	// ReceiptStoreInvalidRequestBadLimit bad limit
+	ReceiptStoreInvalidRequestBadLimit = "Invalid 'limit' query parameter"
+	// ReceiptStoreInvalidRequestBadSkip bad skip
+	ReceiptStoreInvalidRequestBadSkip = "Invalid 'skip' query parameter"
+	// ReceiptStoreInvalidRequestBadSince bad since
+	ReceiptStoreInvalidRequestBadSince = "since cannot be parsed as RFC3339 or millisecond timestamp"
+	// ReceiptStoreFailedQuery wrapper over detailed error
+	ReceiptStoreFailedQuery = "Error querying replies: %s"
+	// ReceiptStoreFailedQuerySingle wrapper over detailed error
+	ReceiptStoreFailedQuerySingle = "Error querying reply: %s"
+	// ReceiptStoreFailedNotFound receipt isn't in the store
+	ReceiptStoreFailedNotFound = "Receipt not available"
+
+	// RemoteRegistryCacheInit initialzation issue for remote contract registry
+	RemoteRegistryCacheInit = "Failed to initialize cache for remote registry: %s"
+	// RemoteRegistryNotConfigured cannot register as a remote registry is not configured
+	RemoteRegistryNotConfigured = "No remote registry is configured"
+	// RemoteRegistryRegistrationFailed error during registration with remote contract registry
+	RemoteRegistryRegistrationFailed = "Failed to register instance in remote registry: %s"
+	// RemoteRegistryLookupGatewayNotFound did not find the requested ID in the remote registry for a gateway/factory
+	RemoteRegistryLookupGatewayNotFound = "Gateway not found"
+	// RemoteRegistryLookupInstanceNotFound did not find the requested ID in the remote registry for a contract instance
+	RemoteRegistryLookupInstanceNotFound = "Instance not found"
+	// RemoteRegistryLookupDecodeABIFailed couldn't parse the ABI in the response
+	RemoteRegistryLookupDecodeABIFailed = "Error processing contract registry response"
+	// RemoteRegistryLookupDecodeBytecodeFailed couldn't parse the ABI in the response
+	RemoteRegistryLookupDecodeBytecodeFailed = "Error processing contract registry response"
+
+	// RESTGatewayGatewayNotFound the gateway REST API interface (the 'factory' / ABI generic interface) was not found
+	RESTGatewayGatewayNotFound = "Gateway not found"
+	// RESTGatewayInstanceNotFound the instance REST API interface (an individual registered address) was not found
+	RESTGatewayInstanceNotFound = "Instance not found"
+	// RESTGatewayEventNotDeclared attempt to subscribe to an event on an instance that does not exist
+	RESTGatewayEventNotDeclared = "Event '%s' is not declared in the ABI"
+	// RESTGatewayMethodNotDeclared attempt to invoke a method name that does not exist in the ABI, or register globally for an event that doesn't exist
+	RESTGatewayMethodNotDeclared = "Method or Event '%s' is not declared in the ABI of contract '%s'"
+	// RESTGatewayInvalidToAddress failed to parse a 'to' address supplied on a path
+	RESTGatewayInvalidToAddress = "To Address must be a 40 character hex string (0x prefix is optional)"
+	// RESTGatewayInvalidFromAddress failed to parse a 'from' address supplied on a path
+	RESTGatewayInvalidFromAddress = "From Address must be a 40 character hex string (0x prefix is optional)"
+	// RESTGatewayMissingParameter did not supply a parameter required by the method
+	RESTGatewayMissingParameter = "Parameter '%s' of method '%s' was not specified in body or query parameters"
+	// RESTGatewayMissingFromAddress did not supply a signing address for the transaction
+	RESTGatewayMissingFromAddress = "Please specify a valid address in the 'kld-from' query string parameter or x-kaleido-from HTTP header"
+	// RESTGatewaySubscribeMissingStreamParameter missed the ID of the stream when registering
+	RESTGatewaySubscribeMissingStreamParameter = "Must supply a 'stream' parameter in the body or query"
+	// RESTGatewayMixedPrivateForAndGroupID confused privacy group info, using simple/Tessera style as well as pre-defined/Orion style
+	RESTGatewayMixedPrivateForAndGroupID = "kld-privatefor and kld-privacygroupid are mutually exclusive"
+	// RESTGatewayEventManagerInitFailed constructor failure for event manager
+	RESTGatewayEventManagerInitFailed = "Event-stream subscription manager: %s"
+	// RESTGatewayEventStreamInvalid attempt to create an event stream with invalid parameters
+	RESTGatewayEventStreamInvalid = "Invalid event stream specification: %s"
+	// RESTGatewayPostDeployMissingAddress after deployment the receipt did not contain a contract address
+	RESTGatewayPostDeployMissingAddress = "%s: Missing contract address in receipt"
+	// RESTGatewayRegistrationSuppliedInvalidAddress invalid address when registering an existing instance of a contract
+	RESTGatewayRegistrationSuppliedInvalidAddress = "Invalid address in path - must be a 40 character hex string with optional 0x prefix"
+	// RESTGatewaySyncMsgTypeMismatch sync-invoke code paths in REST API Gateway should be maintained such that this cannot happen
+	RESTGatewaySyncMsgTypeMismatch = "Unexpected condition (message types do not match when processing)"
+	// RESTGatewaySyncWrapErrorWithTXDetail wraps a low level error with transaction hash context on sync APIs before returning
+	RESTGatewaySyncWrapErrorWithTXDetail = "TX %s: %s"
+
+	// RESTGatewayCompileContractInvalidFormData invalid form data when requesting a compilation to generate an ABI/bytecode
+	RESTGatewayCompileContractInvalidFormData = "Could not parse supplied multi-part form data: %s"
+	// RESTGatewayCompileContractCompileFailed failed to perform compile
+	RESTGatewayCompileContractCompileFailed = "Failed to compile solidity: %s"
+	// RESTGatewayCompileContractPostcompileFailed failed to process output of compilation
+	RESTGatewayCompileContractPostcompileFailed = "Failed to process solidity: %s"
+	// RESTGatewayCompileContractExtractedReadFailed failed to read extracted contents of uploaded data
+	RESTGatewayCompileContractExtractedReadFailed = "Failed to read extracted multi-part form data"
+	// RESTGatewayCompileContractNoSOL failed to find any solidity files in uploaded data
+	RESTGatewayCompileContractNoSOL = "No .sol files found in root. Please set a 'source' query param or form field to the relative path of your solidity"
+	// RESTGatewayCompileContractSolcVerFail failed while checking version of solidity compiler 'solc'
+	RESTGatewayCompileContractSolcVerFail = "Failed checking solc version: %s"
+	// RESTGatewayCompileContractCompileFailDetails output from compiler failure
+	RESTGatewayCompileContractCompileFailDetails = "Failed to compile [%s]: %s"
+	// RESTGatewayCompileContractSolcOutputProcessFail failed to process output of compilation
+	RESTGatewayCompileContractSolcOutputProcessFail = "Failed to parse solc output: %s"
+	// RESTGatewayCompileContractSlashes unsafe slash characters in filenames
+	RESTGatewayCompileContractSlashes = "Filenames cannot contain slashes. Use a zip file to upload a directory structure"
+	// RESTGatewayCompileContractUnzipRead error opening zip/tgz to read (no extra information to remote caller)
+	RESTGatewayCompileContractUnzipRead = "Failed to read archive"
+	// RESTGatewayCompileContractUnzipWrite error writing extracted zip (no extra information to remote caller)
+	RESTGatewayCompileContractUnzipWrite = "Failed to process archive"
+	// RESTGatewayCompileContractUnzipCopy error writing extracted zip (no extra information to remote caller)
+	RESTGatewayCompileContractUnzipCopy = "Failed to process archive"
+	// RESTGatewayCompileContractUnzip failure thrown from decompression library during extract
+	RESTGatewayCompileContractUnzip = "Error unarchiving supplied zip file: %s"
+
+	// RESTGatewayLocalStoreContractSave local filesystem storage failure for contract instance (non-registry code flow)
+	RESTGatewayLocalStoreContractSave = "Failed to write ABI JSON: %s"
+	// RESTGatewayLocalStoreContractLoad local filesystem load failure for contract instance (non-registry code flow)
+	RESTGatewayLocalStoreContractLoad = "Failed to find installed contract address for '%s'"
+	// RESTGatewayLocalStoreContractNotFound local filesystem not found (non-registry code flow)
+	RESTGatewayLocalStoreContractNotFound = "No contract instance registered with address %s"
+	// RESTGatewayLocalStoreABINotFound lookup of ABI failed not found (non-registry code flow)
+	RESTGatewayLocalStoreABINotFound = "No ABI found with ID %s"
+	// RESTGatewayLocalStoreABILoad local filesystem load failure for ABI details (non-registry code flow)
+	RESTGatewayLocalStoreABILoad = "Failed to load ABI with ID %s: %s"
+	// RESTGatewayLocalStoreABIParse local filesystem parse failure for ABI details (non-registry code flow)
+	RESTGatewayLocalStoreABIParse = "Failed to parse ABI with ID %s: %s"
+	// RESTGatewayLocalStoreMissingABI did not supply ABI JSON when attempting to install ABI (non-registry code flow)
+	RESTGatewayLocalStoreMissingABI = "Must supply ABI to install an existing ABI into the REST Gateway"
+	// RESTGatewayLocalStoreContractSavePostDeploy local filesystem storage failure for contract instance post deploy (non-registry code flow)
+	RESTGatewayLocalStoreContractSavePostDeploy = "%s: Failed to write deployment details: %s"
+	// RESTGatewayFriendlyNameClash duplicate friendly name when reigstering
+	RESTGatewayFriendlyNameClash = "Contract address %s is already registered for name '%s'"
+
+	// RPCCallReturnedError specified RPC call returned error
+	RPCCallReturnedError = "%s returned: %s"
+	// RPCConnectFailed error connecting to back-end server over JSON/RPC
+	RPCConnectFailed = "JSON/RPC connection to %s failed: %s"
+
+	// SecurityModulePluginLoad failed to load .so
+	SecurityModulePluginLoad = "Failed to load plugin: %s"
+	// SecurityModulePluginSymbol missing symbol in plugin
+	SecurityModulePluginSymbol = "Failed to load 'SecurityModule' symbol from '%s': %s"
+	// SecurityModuleNoAuthContext missing auth context in context object at point security module is invoked
+	SecurityModuleNoAuthContext = "No auth context"
+
+	// TransactionSendConstructorPackArgs RLP encoding failure for a constructor
+	TransactionSendConstructorPackArgs = "Packing arguments for constructor: %s"
+	// TransactionSendMethodPackArgs RLP encoding failure for a method
+	TransactionSendMethodPackArgs = "Packing arguments for method '%s': %s"
+	// TransactionSendInputTypeUnknown there is a type in the ABI inputs that we don't understand
+	TransactionSendInputTypeUnknown = "ABI input %d: Unable to map %s to etherueum type: %s"
+	// TransactionSendOutputTypeUnknown there is a type in the ABI outputs that we don't understand
+	TransactionSendOutputTypeUnknown = "ABI output %d: Unable to map %s to etherueum type: %s"
+	// TransactionSendGasEstimateFailed gas estimation failed prior to sending TX
+	TransactionSendGasEstimateFailed = "Failed to calculate gas for transaction: %s"
+	// TransactionSendCallFailedNoRevert failed to perform an eth_call with a JSON/RPC error (not a revert)
+	TransactionSendCallFailedNoRevert = "Call failed: %s"
+	// TransactionSendCallFailedRevertMessage directly passes the revert message from the EVM
+	TransactionSendCallFailedRevertMessage = "%s"
+	// TransactionSendCallFailedRevertNoMessage when we couldn't process the EVM revert message
+	TransactionSendCallFailedRevertNoMessage = "EVM reverted. Failed to decode error message"
+	// TransactionSendMissingPrivateFromOrion there is no default privateFrom in Orion, so the user must always supply it
+	TransactionSendMissingPrivateFromOrion = "private-from is required when submitting private transactions via Orion"
+	// TransactionSendPrivateTXWithExternalSigner we don't allow private transactions to be combined with a HD Wallet or other external signer currently
+	TransactionSendPrivateTXWithExternalSigner = "Signing with %s is not currently supported with private transactions"
+	// TransactionSendPrivateForAndPrivactyGroup mixed both params
+	TransactionSendPrivateForAndPrivactyGroup = "privacyGroupId and privateFor are mutually exclusive"
+	// TransactionSendNonceFailWithPrivacyGroup when we successfully lookup the privacy group, but cannot get the nonce
+	TransactionSendNonceFailWithPrivacyGroup = "priv_getTransactionCount for privacy group '%s' returned: %s"
+	// TransactionSendMissingMethod a request to send a transaction was received (webhook/Kafka) that was missing method details (unexpected when using REST APIs that validate this)
+	TransactionSendMissingMethod = "Method missing - must provide inline 'param' type/value pairs with a 'methodName', or an ABI in 'method'"
+	// TransactionSendBadNonce a user-supplied nonce string in the JSON input cannot be processed
+	TransactionSendBadNonce = "Converting supplied 'nonce' to integer: %s"
+	// TransactionSendBadValue a user-supplied value (eth amount to transfer) string in the JSON input cannot be processed
+	TransactionSendBadValue = "Converting supplied 'value' to big integer: %s"
+	// TransactionSendBadGas a user-supplied gas (maximum gas to spend on the TX) string in the JSON input cannot be processed
+	TransactionSendBadGas = "Converting supplied 'gas' to integer: %s"
+	// TransactionSendBadGasPrice a user-supplied gasPrice (eth to pay for each unit of gas spent) string in the JSON input cannot be processed
+	TransactionSendBadGasPrice = "Converting supplied 'gasPrice' to big integer"
+	// TransactionSendInputTypeBadNumber the input JSON value supplied for a method parameter cannot be converted to a number
+	TransactionSendInputTypeBadNumber = "Method '%s' param %d: Could not be converted to a number"
+	// TransactionSendInputTypeBadJSONTypeForNumber the input JSON value supplied for a method parameter was not a number or a string, and needs to be converted to a number
+	TransactionSendInputTypeBadJSONTypeForNumber = "Method '%s' param %d is a %s: Must supply a number or a string"
+	// TransactionSendInputTypeBadJSONTypeForArray the input JSON value supplied for a method parameter was not compatible with coercion to an array
+	TransactionSendInputTypeBadJSONTypeForArray = "Method '%s' param %d is a %s: Must supply an array"
+	// TransactionSendInputTypeBadNull the input JSON value supplied was null
+	TransactionSendInputTypeBadNull = "Method '%s' param %d: Cannot supply a null value"
+	// TransactionSendInputTypeBadJSONTypeForBoolean the input JSON value supplied for a method parameter was not compatible with coercion to a boolean
+	TransactionSendInputTypeBadJSONTypeForBoolean = "Method '%s' param %d is a %s: Must supply a boolean or a string"
+	// TransactionSendInputTypeBadJSONTypeForString the input JSON value supplied for a method parameter was not compatible with coercion to a boolean
+	TransactionSendInputTypeBadJSONTypeForString = "Method '%s' param %d: Must supply a string"
+	// TransactionSendInputTypeAddress the input JSON value supplied for a method parameter couldn't be parsed as an eth address
+	TransactionSendInputTypeAddress = "Method '%s' param %d: Could not be converted to a hex address"
+	// TransactionSendInputTypeBadJSONTypeForAddress the input JSON value supplied for a method parameter was not compatible with coercion to an eth address
+	TransactionSendInputTypeBadJSONTypeForAddress = "Method '%s' param %d is a %s: Must supply a hex address string"
+	// TransactionSendInputTypeBadJSONTypeInNumericArray one of the entries inside of a numeric array, is not valid as a number
+	TransactionSendInputTypeBadJSONTypeInNumericArray = "Method '%s' param %d is a %s: Invalid entry in number array at index %d (%s)"
+	// TransactionSendInputTypeBadByteOutsideRange one of the entries inside of a byte array, is a number outside the range for bytes
+	TransactionSendInputTypeBadByteOutsideRange = "Method '%s' param %d is a %s: Invalid number - outside of range for byte"
+	// TransactionSendInputTypeBadJSONTypeForBytes one of the entries inside of a byte array, is a number outside the range for bytes
+	TransactionSendInputTypeBadJSONTypeForBytes = "Method '%s' param %d is a %s: Must supply a hex string, or number array"
+	// TransactionSendInputTypeNotSupported did not know how to handle this type - enhancement required
+	TransactionSendInputTypeNotSupported = "Type '%s' is not yet supported"
+	// TransactionSendInputCountMismatch wrong number of args supplied according to the ABI
+	TransactionSendInputCountMismatch = "Method '%s': Requires %d args (supplied=%d)"
+	// TransactionSendInputStructureWrong the JSON structure supplied to decribe the arguments is incorrect according to our schema
+	TransactionSendInputStructureWrong = "Param %d: supplied as an object must have 'type' and 'value' fields"
+	// TransactionSendInputInLineTypeArrayNotString when sending us an ABI definition for the inputs directly
+	TransactionSendInputInLineTypeArrayNotString = "Param %d: supplied as an object must be string"
+	// TransactionSendInputInLineTypeUnknown when sending us an ABI definition for the inputs directly, the type string isn't known as an ethereum type
+	TransactionSendInputInLineTypeUnknown = "Param %d: Unable to map %s to etherueum type: %s"
+	// TransactionSendMsgTypeUnknown we got a JSON message into the core processor (from Kafka, Webhooks etc.) that we don't understand
+	TransactionSendMsgTypeUnknown = "Unknown message type '%s'"
+
+	// TransactionSendReceiptCheckError we continually had bad RCs back from the node while trying to check for the receipt up to the timeout
+	TransactionSendReceiptCheckError = "Error obtaining transaction receipt (%d retries): %s"
+	// TransactionSendReceiptCheckTimeout we didn't have a problem asking the node for a receipt, but the transaction wasn't mined at the end of the timeout
+	TransactionSendReceiptCheckTimeout = "Timed out waiting for transaction receipt"
+
+	// UnpackOutputsFailed RLP decoding of outputs, logs, or events failed
+	UnpackOutputsFailed = "Failed to unpack values: %s"
+	// UnpackOutputsMismatch RLP decoding of output gave an unexpected type according to the ABI
+	UnpackOutputsMismatch = "Expected %d type in JSON/RPC response. Received %d: %+v"
+	// UnpackOutputsMismatchCount wrong number of arguments
+	UnpackOutputsMismatchCount = "Expected %d in JSON/RPC response. Received %d: %+v"
+	// UnpackOutputsMismatchNil RLP decoding of output gave a non-nil type, and we expected nil
+	UnpackOutputsMismatchNil = "Expected nil in JSON/RPC response. Received: %+v"
+	// UnpackOutputsMismatchType expected to find a number according to supplied ABI, but got something else
+	UnpackOutputsMismatchType = "Expected %s type in JSON/RPC response for %s (%s). Received %s"
+	// UnpackOutputsUnknownType did not know how to handle this type - enhancement required
+	UnpackOutputsUnknownType = "Unable to process type for %s (%s). Received %s"
+
+	// Unauthorized (401 error)
+	Unauthorized = "Unauthorized"
+
+	// WebhooksInvalidMsgHeaders missing headers section in the JSON/YAML posted
+	WebhooksInvalidMsgHeaders = "Invalid message - missing 'headers' (or not an object)"
+	// WebhooksInvalidMsgTypeMissing need to specify a msg type in the header
+	WebhooksInvalidMsgTypeMissing = "Invalid message - missing 'headers.type' (or not a string)"
+	// WebhooksInvalidMsgFromMissing need to specify a msg type in the header
+	WebhooksInvalidMsgFromMissing = "Invalid message - missing 'from' (or not a string)"
+	// WebhooksInvalidMsgType need to specify a valid msg type in the header
+	WebhooksInvalidMsgType = "Invalid message type: %s"
+	// WebhooksKafkaUnexpectedErrFmt problem processing an error that came back from Kafka, so do a deep dump
+	WebhooksKafkaUnexpectedErrFmt = "Error did not contain message and metadata: %+v"
+	// WebhooksKafkaDeliveryReportNoMeta delivery reports should contain the metadata we set when we sent
+	WebhooksKafkaDeliveryReportNoMeta = "Sent message did not contain metadata: %+v"
+	// WebhooksKafkaYAMLtoJSON re-serialization of webhook message into JSON failed
+	WebhooksKafkaYAMLtoJSON = "Unable to reserialize YAML payload as JSON: %s"
+	// WebhooksKafkaErr wrapper on detailed error from Kafka itself
+	WebhooksKafkaErr = "Failed to deliver message to Kafka: %s"
+
+	// WebhooksDirectTooManyInflight when we're not using a buffered store (Kafka) we have to reject
+	WebhooksDirectTooManyInflight = "Too many in-flight transactions"
+	// WebhooksDirectBadHeaders problem processing for in-memory operation
+	WebhooksDirectBadHeaders = "Failed to process headers in message"
+)
+
+type kldError string
+
+func (e kldError) Error() string {
+	return string(e)
+}
+
+// Errorf creates an error (not yet translated, but an extensible interface for that using simple sprintf formatting rather than named i18n inserts)
+func Errorf(msg ErrorID, inserts ...interface{}) error {
+	var err error = kldError(fmt.Sprintf(string(msg), inserts...))
+	return errors.WithStack(err)
+}

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -89,12 +89,12 @@ const (
 	EventStreamsDBLoad = "Failed to open DB at %s: %s"
 	// EventStreamsNoID attempt to create an event stream/sub without an ID
 	EventStreamsNoID = "No ID"
+	// EventStreamsInvalidActionType unknown action type
+	EventStreamsInvalidActionType = "Unknown action type '%s'"
 	// EventStreamsWebhookNoURL attempt to create a Webhook event stream without a URL
 	EventStreamsWebhookNoURL = "Must specify webhook.url for action type 'webhook'"
 	// EventStreamsWebhookInvalidURL attempt to create a Webhook event stream with an invalid URL
 	EventStreamsWebhookInvalidURL = "Invalid URL in webhook action"
-	// EventStreamsWebhookInvalidActionType unknown action type
-	EventStreamsWebhookInvalidActionType = "Unknown action type '%s'"
 	// EventStreamsWebhookResumeActive resume when already resumed
 	EventStreamsWebhookResumeActive = "Event processor is already active. Suspending:%t"
 	// EventStreamsWebhookProhibitedAddress some IP ranges can be restricted

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -34,9 +34,9 @@ const (
 
 	// ConfigFileReadFailed failed to read the server config file
 	ConfigFileReadFailed = "Failed to read %s: %s"
-	// CompilerVerionNotFound the runtime context of ethconnect has not been configured with a compiler for the requested version
+	// CompilerVersionNotFound the runtime context of ethconnect has not been configured with a compiler for the requested version
 	CompilerVersionNotFound = "Could not find a configured compiler for requested Solidity major version %s.%s"
-	// CompilerVerionBadRequest the user requested a bad semver
+	// CompilerVersionBadRequest the user requested a bad semver
 	CompilerVersionBadRequest = "Invalid Solidity version requested for compiler. Ensure the string starts with two dot separated numbers, such as 0.5"
 	// CompilerFailedSolc compilation failure output from solc
 	CompilerFailedSolc = "Solidity compilation failed: solc: %v\n%s"
@@ -132,7 +132,7 @@ const (
 	HDWalletSigningFailed = "HDWallet signing failed"
 	// HDWalletSigningBadData we got a response, but not with the correct fields
 	HDWalletSigningBadData = "Unexpected response from HDWallet"
-	// HDWalletSigningNoConfog we had a request for HD Wallet signing, but we don't have the required config
+	// HDWalletSigningNoConfig we had a request for HD Wallet signing, but we don't have the required config
 	HDWalletSigningNoConfig = "No HD Wallet Configuration"
 
 	// HelperStrToAddressRequiredField re-usable error for missing fields
@@ -240,7 +240,7 @@ const (
 	RESTGatewayCompileContractInvalidFormData = "Could not parse supplied multi-part form data: %s"
 	// RESTGatewayCompileContractCompileFailed failed to perform compile
 	RESTGatewayCompileContractCompileFailed = "Failed to compile solidity: %s"
-	// RESTGatewayCompileContractPostcompileFailed failed to process output of compilation
+	// RESTGatewayCompileContractPostCompileFailed failed to process output of compilation
 	RESTGatewayCompileContractPostCompileFailed = "Failed to process solidity: %s"
 	// RESTGatewayCompileContractExtractedReadFailed failed to read extracted contents of uploaded data
 	RESTGatewayCompileContractExtractedReadFailed = "Failed to read extracted multi-part form data"
@@ -314,7 +314,7 @@ const (
 	TransactionSendMissingPrivateFromOrion = "private-from is required when submitting private transactions via Orion"
 	// TransactionSendPrivateTXWithExternalSigner we don't allow private transactions to be combined with a HD Wallet or other external signer currently
 	TransactionSendPrivateTXWithExternalSigner = "Signing with %s is not currently supported with private transactions"
-	// TransactionSendPrivateForAndPrivactyGroup mixed both params
+	// TransactionSendPrivateForAndPrivacyGroup mixed both params
 	TransactionSendPrivateForAndPrivacyGroup = "privacyGroupId and privateFor are mutually exclusive"
 	// TransactionSendNonceFailWithPrivacyGroup when we successfully lookup the privacy group, but cannot get the nonce
 	TransactionSendNonceFailWithPrivacyGroup = "priv_getTransactionCount for privacy group '%s' returned: %s"

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -315,7 +315,7 @@ const (
 	// TransactionSendPrivateTXWithExternalSigner we don't allow private transactions to be combined with a HD Wallet or other external signer currently
 	TransactionSendPrivateTXWithExternalSigner = "Signing with %s is not currently supported with private transactions"
 	// TransactionSendPrivateForAndPrivactyGroup mixed both params
-	TransactionSendPrivateForAndPrivactyGroup = "privacyGroupId and privateFor are mutually exclusive"
+	TransactionSendPrivateForAndPrivacyGroup = "privacyGroupId and privateFor are mutually exclusive"
 	// TransactionSendNonceFailWithPrivacyGroup when we successfully lookup the privacy group, but cannot get the nonce
 	TransactionSendNonceFailWithPrivacyGroup = "priv_getTransactionCount for privacy group '%s' returned: %s"
 	// TransactionSendMissingMethod a request to send a transaction was received (webhook/Kafka) that was missing method details (unexpected when using REST APIs that validate this)

--- a/internal/kldeth/compiler.go
+++ b/internal/kldeth/compiler.go
@@ -66,10 +66,10 @@ func getSolcExecutable(requestedVersion string) (string, error) {
 		if envVar := os.Getenv(envVarName); envVar != "" {
 			solc = envVar
 		} else {
-			return "", klderrors.Errorf(klderrors.CompilerVerionNotFound, v[1], v[2])
+			return "", klderrors.Errorf(klderrors.CompilerVersionNotFound, v[1], v[2])
 		}
 	} else if requestedVersion != "" {
-		return "", klderrors.Errorf(klderrors.CompilerVerionBadRequest)
+		return "", klderrors.Errorf(klderrors.CompilerVersionBadRequest)
 	}
 	log.Debugf("Solidity compiler solc binary: %s", solc)
 	return solc, nil

--- a/internal/kldeth/compiler.go
+++ b/internal/kldeth/compiler.go
@@ -17,7 +17,6 @@ package kldeth
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"reflect"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common/compiler"
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 )
 
 const (
@@ -66,10 +66,10 @@ func getSolcExecutable(requestedVersion string) (string, error) {
 		if envVar := os.Getenv(envVarName); envVar != "" {
 			solc = envVar
 		} else {
-			return "", fmt.Errorf("Could not find a configured compiler for requested Solidity major version %s.%s", v[1], v[2])
+			return "", klderrors.Errorf(klderrors.CompilerVerionNotFound, v[1], v[2])
 		}
 	} else if requestedVersion != "" {
-		return "", fmt.Errorf("Invalid Solidity version requested for compiler. Ensure the string starts with two dot separated numbers, such as 0.5")
+		return "", klderrors.Errorf(klderrors.CompilerVerionBadRequest)
 	}
 	log.Debugf("Solidity compiler solc binary: %s", solc)
 	return solc, nil
@@ -113,7 +113,7 @@ func CompileContract(soliditySource, contractName, requestedVersion, evmVersion 
 	cmd.Stderr = &stderr
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("Solidity compilation failed: solc: %v\n%s", err, stderr.String())
+		return nil, klderrors.Errorf(klderrors.CompilerFailedSolc, err, stderr.String())
 	}
 	c, err := compiler.ParseCombinedJSON(stdout.Bytes(), soliditySource, s.Version, s.Version, strings.Join(solcArgs, " "))
 	return ProcessCompiled(c, contractName, true)
@@ -129,11 +129,11 @@ func ProcessCompiled(compiled map[string]*compiler.Contract, contractName string
 			contractName = "<stdin>:" + contractName
 		}
 		if _, ok := compiled[contractName]; !ok {
-			return nil, fmt.Errorf("Contract '%s' not found in Solidity source: %s", contractName, contractNames)
+			return nil, klderrors.Errorf(klderrors.CompilerOutputMissingContract, contractName, contractNames)
 		}
 		contract = compiled[contractName]
 	} else if len(contractNames) != 1 {
-		return nil, fmt.Errorf("More than one contract in Solidity file, please set one to call: %s", contractNames)
+		return nil, klderrors.Errorf(klderrors.CompilerOutputMultipleContracts, contractNames)
 	} else {
 		contractName = contractNames[0].String()
 		contract = compiled[contractName]
@@ -154,24 +154,24 @@ func packContract(contractName string, contract *compiler.Contract) (c *Compiled
 	}
 	c.Compiled, err = hexutil.Decode(contract.Code)
 	if err != nil {
-		return nil, fmt.Errorf("Decoding bytecode: %s", err)
+		return nil, klderrors.Errorf(klderrors.CompilerBytecodeInvalid, err)
 	}
 	if len(c.Compiled) == 0 {
-		return nil, fmt.Errorf("Specified contract compiled ok, but did not result in any bytecode: %s", contractName)
+		return nil, klderrors.Errorf(klderrors.CompilerBytecodeEmpty, contractName)
 	}
 	// Pack the arguments for calling the contract
 	abiJSON, err := json.Marshal(contract.Info.AbiDefinition)
 	if err != nil {
-		return nil, fmt.Errorf("Serializing ABI: %s", err)
+		return nil, klderrors.Errorf(klderrors.CompilerABISerialize, err)
 	}
 	abi, err := abi.JSON(bytes.NewReader(abiJSON))
 	if err != nil {
-		return nil, fmt.Errorf("Parsing ABI: %s", err)
+		return nil, klderrors.Errorf(klderrors.CompilerABIReRead, err)
 	}
 	c.ABI = &abi
 	devdocBytes, err := json.Marshal(contract.Info.DeveloperDoc)
 	if err != nil {
-		return nil, fmt.Errorf("Serializing DevDoc: %s", err)
+		return nil, klderrors.Errorf(klderrors.CompilerSerializeDevDocs, err)
 	}
 	c.DevDoc = string(devdocBytes)
 	return c, nil

--- a/internal/kldeth/getreceipt.go
+++ b/internal/kldeth/getreceipt.go
@@ -16,9 +16,9 @@ package kldeth
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -30,7 +30,7 @@ func (tx *Txn) GetTXReceipt(ctx context.Context, rpc RPCClient) (bool, error) {
 	defer cancel()
 
 	if err := rpc.CallContext(ctx, &tx.Receipt, "eth_getTransactionReceipt", tx.Hash); err != nil {
-		return false, fmt.Errorf("eth_getTransactionReceipt returned: %s", err)
+		return false, klderrors.Errorf(klderrors.RPCCallReturnedError, "eth_getTransactionReceipt", err)
 	}
 	callTime := time.Now().UTC().Sub(start)
 	isMined := tx.Receipt.BlockNumber != nil && tx.Receipt.BlockNumber.ToInt().Uint64() > 0
@@ -39,7 +39,7 @@ func (tx *Txn) GetTXReceipt(ctx context.Context, rpc RPCClient) (bool, error) {
 	if tx.PrivacyGroupID != "" {
 		// priv_getTransactionReceipt expects the txHash and the public key of enclave (privateFrom)
 		if err := rpc.CallContext(ctx, &tx.Receipt, "priv_getTransactionReceipt", tx.Hash, tx.PrivateFrom); err != nil {
-			return false, fmt.Errorf("priv_getTransactionReceipt returned: %s", err)
+			return false, klderrors.Errorf(klderrors.RPCCallReturnedError, "priv_getTransactionReceipt", err)
 		}
 	}
 

--- a/internal/kldeth/privacygroup.go
+++ b/internal/kldeth/privacygroup.go
@@ -16,10 +16,10 @@ package kldeth
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 )
 
 // OrionPrivacyGroup is the result of the priv_findPrivacyGroup call
@@ -41,11 +41,11 @@ func GetOrionPrivacyGroup(ctx context.Context, rpc RPCClient, addr *common.Addre
 	var privacyGroups []OrionPrivacyGroup
 	var privacyGroup string
 	if err := rpc.CallContext(ctx, &privacyGroups, "priv_findPrivacyGroup", allMembers); err != nil {
-		return "", fmt.Errorf("priv_findPrivacyGroup returned: %s", err)
+		return "", klderrors.Errorf(klderrors.RPCCallReturnedError, "priv_findPrivacyGroup", err)
 	}
 	if len(privacyGroups) == 0 {
 		if err := rpc.CallContext(ctx, &privacyGroup, "priv_createPrivacyGroup", params); err != nil {
-			return "", fmt.Errorf("priv_createPrivacyGroup returned: %s", err)
+			return "", klderrors.Errorf(klderrors.RPCCallReturnedError, "priv_createPrivacyGroup", err)
 		}
 	} else {
 		privacyGroup = privacyGroups[0].PrivacyGroupID

--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -1439,7 +1439,7 @@ func TestProcessRLPBytesInvalidBool(t *testing.T) {
 
 	t1, _ := kldbind.ABITypeFor("bool")
 	_, err := mapOutput("test1", "bool", &t1, "not a bool")
-	assert.EqualError(err, "Expected boolean in JSON/RPC response for test1 (bool). Received string")
+	assert.EqualError(err, "Expected boolean type in JSON/RPC response for test1 (bool). Received string")
 }
 
 func TestProcessRLPBytesInvalidString(t *testing.T) {
@@ -1447,7 +1447,7 @@ func TestProcessRLPBytesInvalidString(t *testing.T) {
 
 	t1, _ := kldbind.ABITypeFor("string")
 	_, err := mapOutput("test1", "string", &t1, 42)
-	assert.EqualError(err, "Expected string array in JSON/RPC response for test1 (string). Received int")
+	assert.EqualError(err, "Expected string array type in JSON/RPC response for test1 (string). Received int")
 }
 
 func TestProcessRLPBytesInvalidByteArray(t *testing.T) {
@@ -1455,7 +1455,7 @@ func TestProcessRLPBytesInvalidByteArray(t *testing.T) {
 
 	t1, _ := kldbind.ABITypeFor("address")
 	_, err := mapOutput("test1", "address", &t1, 42)
-	assert.EqualError(err, "Expected []byte array in JSON/RPC response for test1 (address). Received int")
+	assert.EqualError(err, "Expected []byte type in JSON/RPC response for test1 (address). Received int")
 }
 
 func TestProcessRLPBytesInvalidArray(t *testing.T) {
@@ -1463,7 +1463,7 @@ func TestProcessRLPBytesInvalidArray(t *testing.T) {
 
 	t1, _ := kldbind.ABITypeFor("int32[]")
 	_, err := mapOutput("test1", "int32[]", &t1, 42)
-	assert.EqualError(err, "Expected slice in JSON/RPC response for test1 (int32[]). Received int")
+	assert.EqualError(err, "Expected slice type in JSON/RPC response for test1 (int32[]). Received int")
 }
 
 func TestProcessRLPBytesInvalidArrayType(t *testing.T) {
@@ -1560,5 +1560,5 @@ func TestProcessOutputsBadArgs(t *testing.T) {
 	}
 
 	err := processOutputs(methodABI.Outputs, []interface{}{"arg1"}, make(map[string]interface{}))
-	assert.EqualError(err, "Expected slice in JSON/RPC response for retval1 (int32[]). Received string")
+	assert.EqualError(err, "Expected slice type in JSON/RPC response for retval1 (int32[]). Received string")
 }

--- a/internal/kldeth/txncount.go
+++ b/internal/kldeth/txncount.go
@@ -16,13 +16,13 @@ package kldeth
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 )
 
 // GetOrionTXCount uses the special Pantheon/Orion interface to check the
@@ -35,7 +35,7 @@ func GetOrionTXCount(ctx context.Context, rpc RPCClient, addr *common.Address, p
 
 	var txnCount hexutil.Uint64
 	if err := rpc.CallContext(ctx, &txnCount, "priv_getTransactionCount", addr, privacyGroup); err != nil {
-		return 0, fmt.Errorf("priv_getTransactionCount for privacy group '%s' returned: %s", privacyGroup, err)
+		return 0, klderrors.Errorf(klderrors.TransactionSendNonceFailWithPrivacyGroup, privacyGroup, err)
 	}
 	callTime := time.Now().UTC().Sub(start)
 	log.Debugf("priv_getTransactionCount(%x,%s)=%d [%.2fs]", addr, privacyGroup, txnCount, callTime.Seconds())
@@ -52,7 +52,7 @@ func GetTransactionCount(ctx context.Context, rpc RPCClient, addr *common.Addres
 
 	var txnCount hexutil.Uint64
 	if err := rpc.CallContext(ctx, &txnCount, "eth_getTransactionCount", addr, blockNumber); err != nil {
-		return 0, fmt.Errorf("eth_getTransactionCount returned: %s", err)
+		return 0, klderrors.Errorf(klderrors.RPCCallReturnedError, "eth_getTransactionCount", err)
 	}
 	callTime := time.Now().UTC().Sub(start)
 	log.Debugf("eth_getTransactionCount(%x,latest)=%d [%.2fs]", addr, txnCount, callTime.Seconds())

--- a/internal/kldevents/eventstream.go
+++ b/internal/kldevents/eventstream.go
@@ -125,7 +125,7 @@ func newEventStream(sm subscriptionManager, spec *StreamInfo) (a *eventStream, e
 			spec.Webhook.RequestTimeoutSec = 30000
 		}
 	default:
-		return nil, klderrors.Errorf(klderrors.EventStreamsWebhookInvalidActionType, spec.Type)
+		return nil, klderrors.Errorf(klderrors.EventStreamsInvalidActionType, spec.Type)
 	}
 
 	if strings.ToLower(spec.ErrorHandling) == ErrorHandlingBlock {

--- a/internal/kldevents/submanager_test.go
+++ b/internal/kldevents/submanager_test.go
@@ -234,7 +234,7 @@ func TestStreamAndSubscriptionErrors(t *testing.T) {
 	_, err = sm.AddSubscription(ctx, nil, &kldbind.ABIEvent{Name: "any"}, "nope", "")
 	assert.EqualError(err, "Stream with ID 'nope' not found")
 	_, err = sm.AddSubscription(ctx, nil, &kldbind.ABIEvent{Name: "any"}, "teststream", "")
-	assert.EqualError(err, "Failed to store stream: pop")
+	assert.EqualError(err, "Failed to store subscription: pop")
 	_, err = sm.AddSubscription(ctx, nil, &kldbind.ABIEvent{Name: "any"}, "teststream", "!bad integer")
 	assert.EqualError(err, "FromBlock cannot be parsed as a BigInt")
 	sm.subscriptions["testsub"] = &subscription{info: &SubscriptionInfo{}, rpc: sm.rpc}

--- a/internal/kldevents/subscription_test.go
+++ b/internal/kldevents/subscription_test.go
@@ -183,7 +183,7 @@ func TestInitialFilterFail(t *testing.T) {
 		rpc:  kldeth.NewMockRPCClientForSync(fmt.Errorf("pop"), nil),
 	}
 	_, err := s.setInitialBlockHeight(context.Background())
-	assert.EqualError(err, "eth_blockNumber: pop")
+	assert.EqualError(err, "eth_blockNumber returned: pop")
 }
 
 func TestInitialFilterBadInitialBlock(t *testing.T) {
@@ -195,7 +195,7 @@ func TestInitialFilterBadInitialBlock(t *testing.T) {
 		rpc: kldeth.NewMockRPCClientForSync(fmt.Errorf("pop"), nil),
 	}
 	_, err := s.setInitialBlockHeight(context.Background())
-	assert.EqualError(err, "Failed to parse FromBlock as BigInt: !integer")
+	assert.EqualError(err, "FromBlock cannot be parsed as a BigInt")
 }
 
 func TestInitialFilterCustomInitialBlock(t *testing.T) {
@@ -217,7 +217,7 @@ func TestRestartFilterFail(t *testing.T) {
 		rpc:  kldeth.NewMockRPCClientForSync(fmt.Errorf("pop"), nil),
 	}
 	err := s.restartFilter(context.Background(), big.NewInt(0))
-	assert.EqualError(err, "eth_newFilter: pop")
+	assert.EqualError(err, "eth_newFilter returned: pop")
 }
 
 func TestUnsubscribe(t *testing.T) {

--- a/internal/kldkafka/kafkacommon.go
+++ b/internal/kldkafka/kafkacommon.go
@@ -16,7 +16,6 @@ package kldkafka
 
 import (
 	"crypto/tls"
-	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
@@ -27,6 +26,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	"github.com/kaleido-io/ethconnect/internal/kldutils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -97,16 +97,16 @@ func (k *kafkaCommon) ValidateConf() error {
 // KafkaValidateConf validates supplied configuration
 func KafkaValidateConf(kconf *KafkaCommonConf) (err error) {
 	if kconf.TopicOut == "" {
-		return fmt.Errorf("No output topic specified for bridge to send events to")
+		return klderrors.Errorf(klderrors.ConfigKafkaMissingOutputTopic)
 	}
 	if kconf.TopicIn == "" {
-		return fmt.Errorf("No input topic specified for bridge to listen to")
+		return klderrors.Errorf(klderrors.ConfigKafkaMissingInputTopic)
 	}
 	if kconf.ConsumerGroup == "" {
-		return fmt.Errorf("No consumer group specified")
+		return klderrors.Errorf(klderrors.ConfigKafkaMissingConsumerGroup)
 	}
 	if !kldutils.AllOrNoneReqd(kconf.SASL.Username, kconf.SASL.Password) {
-		err = fmt.Errorf("Username and Password must both be provided for SASL")
+		err = klderrors.Errorf(klderrors.ConfigKafkaMissingBadSASL)
 		return
 	}
 	return
@@ -161,7 +161,7 @@ func (k *kafkaCommon) connect() (err error) {
 
 	log.Debugf("Kafka Bootstrap brokers: %s", k.conf.Brokers)
 	if len(k.conf.Brokers) == 0 || k.conf.Brokers[0] == "" {
-		err = fmt.Errorf("No Kafka brokers configured")
+		err = klderrors.Errorf(klderrors.ConfigKafkaMissingBrokers)
 		return
 	}
 

--- a/internal/kldkvstore/kvstore.go
+++ b/internal/kldkvstore/kvstore.go
@@ -15,8 +15,7 @@
 package kldkvstore
 
 import (
-	"fmt"
-
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	log "github.com/sirupsen/logrus"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
@@ -104,7 +103,7 @@ func NewLDBKeyValueStore(ldbPath string) (kv KVStore, err error) {
 		path: ldbPath,
 	}
 	if store.db, err = leveldb.OpenFile(ldbPath, nil); err != nil {
-		return nil, fmt.Errorf("Failed to open DB at %s: %s", ldbPath, err)
+		return nil, klderrors.Errorf(klderrors.KVStoreDBLoad, ldbPath, err)
 	}
 	kv = store
 	return

--- a/internal/kldrest/memreceipts.go
+++ b/internal/kldrest/memreceipts.go
@@ -16,9 +16,9 @@ package kldrest
 
 import (
 	"container/list"
-	"fmt"
 	"sync"
 
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -42,7 +42,7 @@ func (m *memoryReceipts) GetReceipts(skip, limit int, ids []string, sinceEpochMS
 	defer m.mux.Unlock()
 
 	if len(ids) > 0 || sinceEpochMS != 0 || from != "" || to != "" {
-		return nil, fmt.Errorf("Memory receipts do not support filtering")
+		return nil, klderrors.Errorf(klderrors.KVStoreMemFilteringUnsupported)
 	}
 
 	results := make([]map[string]interface{}, 0, limit)

--- a/internal/kldrest/mongoreceipts.go
+++ b/internal/kldrest/mongoreceipts.go
@@ -15,11 +15,11 @@
 package kldrest
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -46,7 +46,7 @@ func (m *mongoReceipts) connect() (err error) {
 	}
 	err = m.mgo.Connect(m.conf.URL, time.Duration(m.conf.ConnectTimeoutMS)*time.Millisecond)
 	if err != nil {
-		err = fmt.Errorf("Unable to connect to MongoDB: %s", err)
+		err = klderrors.Errorf(klderrors.ReceiptStoreMongoDBConnect, err)
 		return
 	}
 	m.collection = m.mgo.GetCollection(m.conf.Database, m.conf.Collection)
@@ -65,7 +65,7 @@ func (m *mongoReceipts) connect() (err error) {
 		Sparse:     true,
 	}
 	if err = m.collection.EnsureIndex(index); err != nil {
-		err = fmt.Errorf("Unable to create index: %s", err)
+		err = klderrors.Errorf(klderrors.ReceiptStoreMongoDBIndex, err)
 		return
 	}
 

--- a/internal/kldrest/receiptstore.go
+++ b/internal/kldrest/receiptstore.go
@@ -16,7 +16,6 @@ package kldrest
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -26,6 +25,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/kaleido-io/ethconnect/internal/kldauth"
 	"github.com/kaleido-io/ethconnect/internal/kldcontracts"
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	"github.com/kaleido-io/ethconnect/internal/kldmessages"
 	"github.com/kaleido-io/ethconnect/internal/kldutils"
 	log "github.com/sirupsen/logrus"
@@ -128,7 +128,7 @@ func (r *receiptStore) marshalAndReply(res http.ResponseWriter, req *http.Reques
 	resBytes, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
 		log.Errorf("Error serializing receipts: %s", err)
-		sendRESTError(res, req, fmt.Errorf("Error serializing response"), 500)
+		sendRESTError(res, req, klderrors.Errorf(klderrors.ReceiptStoreSerializeResponse), 500)
 		return
 	}
 	status := 200
@@ -144,13 +144,13 @@ func (r *receiptStore) getReplies(res http.ResponseWriter, req *http.Request, pa
 
 	err := kldauth.AuthListAsyncReplies(req.Context())
 	if err != nil {
-		sendRESTError(res, req, fmt.Errorf("Unauthorized"), 401)
+		sendRESTError(res, req, klderrors.Errorf(klderrors.Unauthorized), 401)
 		return
 	}
 
 	res.Header().Set("Content-Type", "application/json")
 	if r.persistence == nil {
-		sendRESTError(res, req, fmt.Errorf("Receipt store not enabled"), 405)
+		sendRESTError(res, req, klderrors.Errorf(klderrors.ReceiptStoreDisabled), 405)
 		return
 	}
 
@@ -163,7 +163,7 @@ func (r *receiptStore) getReplies(res http.ResponseWriter, req *http.Request, pa
 		for idx, id := range ids {
 			if !uuidCharsVerifier.MatchString(id) {
 				log.Errorf("Invalid id '%s' %d", id, idx)
-				sendRESTError(res, req, fmt.Errorf("Invalid 'id' query parameter"), 400)
+				sendRESTError(res, req, klderrors.Errorf(klderrors.ReceiptStoreInvalidRequestID), 400)
 				return
 			}
 		}
@@ -175,14 +175,14 @@ func (r *receiptStore) getReplies(res http.ResponseWriter, req *http.Request, pa
 		if customLimit, err := strconv.ParseInt(limitStr, 10, 32); err == nil {
 			if int(customLimit) > r.conf.QueryLimit {
 				log.Errorf("Invalid limit value: %s", err)
-				sendRESTError(res, req, fmt.Errorf("Maximum limit is %d", r.conf.QueryLimit), 400)
+				sendRESTError(res, req, klderrors.Errorf(klderrors.ReceiptStoreInvalidRequestMaxLimit, r.conf.QueryLimit), 400)
 				return
 			} else if customLimit > 0 {
 				limit = int(customLimit)
 			}
 		} else {
 			log.Errorf("Invalid limit value: %s", err)
-			sendRESTError(res, req, fmt.Errorf("Invalid 'limit' query parameter"), 400)
+			sendRESTError(res, req, klderrors.Errorf(klderrors.ReceiptStoreInvalidRequestBadLimit), 400)
 			return
 		}
 	}
@@ -195,7 +195,7 @@ func (r *receiptStore) getReplies(res http.ResponseWriter, req *http.Request, pa
 			skip = int(skipI64)
 		} else {
 			log.Errorf("Invalid skip value: %s", err)
-			sendRESTError(res, req, fmt.Errorf("Invalid 'skip' query parameter"), 400)
+			sendRESTError(res, req, klderrors.Errorf(klderrors.ReceiptStoreInvalidRequestBadSkip), 400)
 			return
 		}
 	}
@@ -209,7 +209,7 @@ func (r *receiptStore) getReplies(res http.ResponseWriter, req *http.Request, pa
 		} else {
 			if sinceEpochMS, err = strconv.ParseInt(since, 10, 64); err != nil {
 				log.Errorf("since '%s' cannot be parsed as RFC3339 or millisecond timestamp: %s", since, err)
-				sendRESTError(res, req, fmt.Errorf("since cannot be parsed as RFC3339 or millisecond timestamp"), 400)
+				sendRESTError(res, req, klderrors.Errorf(klderrors.ReceiptStoreInvalidRequestBadSince), 400)
 			}
 		}
 	}
@@ -221,7 +221,7 @@ func (r *receiptStore) getReplies(res http.ResponseWriter, req *http.Request, pa
 	results, err := r.persistence.GetReceipts(skip, limit, ids, sinceEpochMS, from, to)
 	if err != nil {
 		log.Errorf("Error querying replies: %s", err)
-		sendRESTError(res, req, fmt.Errorf("Error querying replies: %s", err), 500)
+		sendRESTError(res, req, klderrors.Errorf(klderrors.ReceiptStoreFailedQuery, err), 500)
 		return
 	}
 	log.Debugf("Replies query: skip=%d limit=%d replies=%d", skip, limit, len(*results))
@@ -235,7 +235,7 @@ func (r *receiptStore) getReply(res http.ResponseWriter, req *http.Request, para
 
 	err := kldauth.AuthReadAsyncReplyByUUID(req.Context())
 	if err != nil {
-		sendRESTError(res, req, fmt.Errorf("Unauthorized"), 401)
+		sendRESTError(res, req, klderrors.Errorf(klderrors.Unauthorized), 401)
 		return
 	}
 
@@ -244,10 +244,10 @@ func (r *receiptStore) getReply(res http.ResponseWriter, req *http.Request, para
 	result, err := r.persistence.GetReceipt(requestID)
 	if err != nil {
 		log.Errorf("Error querying reply: %s", err)
-		sendRESTError(res, req, fmt.Errorf("Error querying reply: %s", err), 500)
+		sendRESTError(res, req, klderrors.Errorf(klderrors.ReceiptStoreFailedQuerySingle, err), 500)
 		return
 	} else if result == nil {
-		sendRESTError(res, req, fmt.Errorf("Receipt not available"), 404)
+		sendRESTError(res, req, klderrors.Errorf(klderrors.ReceiptStoreFailedNotFound), 404)
 		log.Infof("Reply not found")
 		return
 	}

--- a/internal/kldrest/restgateway.go
+++ b/internal/kldrest/restgateway.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/julienschmidt/httprouter"
 	"github.com/kaleido-io/ethconnect/internal/kldauth"
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	"github.com/kaleido-io/ethconnect/internal/kldeth"
 	"github.com/kaleido-io/ethconnect/internal/kldkafka"
 	"github.com/kaleido-io/ethconnect/internal/kldmessages"
@@ -102,14 +103,14 @@ func (g *RESTGateway) SetConf(conf *RESTGatewayConf) {
 // ValidateConf validates the config
 func (g *RESTGateway) ValidateConf() (err error) {
 	if !kldutils.AllOrNoneReqd(g.conf.MongoDB.URL, g.conf.MongoDB.Database, g.conf.MongoDB.Collection) {
-		err = fmt.Errorf("MongoDB URL, Database and Collection name must be specified to enable the receipt store")
+		err = klderrors.Errorf(klderrors.ConfigRESTGatewayRequiredReceiptStore)
 		return
 	}
 	if g.conf.MongoDB.QueryLimit < 1 {
 		g.conf.MongoDB.QueryLimit = 100
 	}
 	if g.conf.OpenAPI.StoragePath != "" && g.conf.RPC.URL == "" {
-		err = fmt.Errorf("RPC URL and Storage Path must be supplied to enable the Open API REST Gateway")
+		err = klderrors.Errorf(klderrors.ConfigRESTGatewayRequiredRPC)
 		return
 	}
 	return

--- a/internal/kldtx/addressbook.go
+++ b/internal/kldtx/addressbook.go
@@ -16,12 +16,12 @@ package kldtx
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	"github.com/kaleido-io/ethconnect/internal/kldeth"
 	"github.com/kaleido-io/ethconnect/internal/kldutils"
 	log "github.com/sirupsen/logrus"
@@ -96,14 +96,14 @@ func (ab *addressBook) resolveHost(endpoint string) (*url.URL, error) {
 	url, err := url.Parse(endpoint)
 	if err != nil {
 		log.Errorf("Invalid URL '%s': %s", endpoint, err)
-		return nil, fmt.Errorf("Invalid URL obtained for address")
+		return nil, klderrors.Errorf(klderrors.AddressBookLookupBadURL)
 	}
 
 	if ab.conf.HostsFile != "" {
 		hostsMap, err := kldutils.ParseHosts(ab.conf.HostsFile)
 		if err != nil {
 			log.Errorf("Failed to parse hosts file: %s", err)
-			return nil, fmt.Errorf("Configuration problem (hosts file)")
+			return nil, klderrors.Errorf(klderrors.AddressBookLookupBadHostsFile)
 		}
 		splitHostPort := strings.Split(url.Host, ":")
 		if mappedHost, ok := hostsMap[splitHostPort[0]]; ok && mappedHost != "" {
@@ -167,7 +167,7 @@ func (ab *addressBook) lookup(ctx context.Context, fromAddr string) (kldeth.RPCC
 		}
 		if body == nil {
 			if ab.fallbackRPCEndpoint == "" {
-				return nil, fmt.Errorf("Unknown address")
+				return nil, klderrors.Errorf(klderrors.AddressBookLookupNotFound)
 			}
 			endpoint = ab.fallbackRPCEndpoint
 		} else {

--- a/internal/kldtx/hdwallet.go
+++ b/internal/kldtx/hdwallet.go
@@ -17,7 +17,6 @@ package kldtx
 import (
 	"bytes"
 	"crypto/ecdsa"
-	"fmt"
 	"math/big"
 	"net/url"
 	"regexp"
@@ -27,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	ecrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	"github.com/kaleido-io/ethconnect/internal/kldeth"
 	"github.com/kaleido-io/ethconnect/internal/kldutils"
 	log "github.com/sirupsen/logrus"
@@ -118,23 +118,23 @@ func (hd *hdWallet) SignerFor(request *HDWalletRequest) (kldeth.TXSigner, error)
 	result, err := hd.hr.DoRequest("GET", urlStr.String(), nil)
 	if err != nil {
 		log.Errorf("HDWallet request failed: %s", err)
-		return nil, fmt.Errorf("HDWallet signing failed")
+		return nil, klderrors.Errorf(klderrors.HDWalletSigningFailed)
 	}
 
 	address, err := hd.hr.GetResponseString(result, hd.conf.PropNames.Address, false)
 	if err != nil {
 		log.Errorf("Missing address in response: %s", err)
-		return nil, fmt.Errorf("Unexpected response from HDWallet")
+		return nil, klderrors.Errorf(klderrors.HDWalletSigningBadData)
 	}
 	keyStr, ok := result[hd.conf.PropNames.PrivateKey].(string)
 	if !ok {
 		log.Errorf("Missing entry in response")
-		return nil, fmt.Errorf("Unexpected response from HDWallet")
+		return nil, klderrors.Errorf(klderrors.HDWalletSigningBadData)
 	}
 	key, err := ecrypto.HexToECDSA(strings.TrimPrefix(keyStr, "0x"))
 	if err != nil {
 		log.Errorf("Bad hex value in response '%s': %s", keyStr, err)
-		return nil, fmt.Errorf("Unexpected response from HDWallet")
+		return nil, klderrors.Errorf(klderrors.HDWalletSigningBadData)
 	}
 
 	return &hdwalletSigner{

--- a/internal/kldtx/txnprocessor.go
+++ b/internal/kldtx/txnprocessor.go
@@ -167,7 +167,7 @@ func (p *txnProcessor) newInflightWrapper(txnContext TxnContext, msg *kldmessage
 	inflight.rpc = p.rpc
 	if hdWalletRequest := IsHDWalletRequest(msg.From); hdWalletRequest != nil {
 		if p.hdwallet == nil {
-			return nil, klderrors.Errorf(klderrors.HDWalletSigningNoConfog)
+			return nil, klderrors.Errorf(klderrors.HDWalletSigningNoConfig)
 		}
 		if inflight.signer, err = p.hdwallet.SignerFor(hdWalletRequest); err != nil {
 			return
@@ -189,7 +189,7 @@ func (p *txnProcessor) newInflightWrapper(txnContext TxnContext, msg *kldmessage
 	// Need to resolve privateFrom/privateFor to a privacyGroupID for Orion
 	if p.conf.OrionPrivateAPIS {
 		if msg.PrivacyGroupID != "" && len(msg.PrivateFor) > 0 {
-			err = klderrors.Errorf(klderrors.TransactionSendPrivateForAndPrivactyGroup)
+			err = klderrors.Errorf(klderrors.TransactionSendPrivateForAndPrivacyGroup)
 			return
 		} else if msg.PrivacyGroupID != "" {
 			inflight.privacyGroupID = msg.PrivacyGroupID

--- a/internal/kldutils/ethutils.go
+++ b/internal/kldutils/ethutils.go
@@ -15,23 +15,23 @@
 package kldutils
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 )
 
 // StrToAddress is a helper to parse eth addresses with useful errors
 func StrToAddress(desc string, strAddr string) (addr common.Address, err error) {
 	if strAddr == "" {
-		err = fmt.Errorf("'%s' must be supplied", desc)
+		err = klderrors.Errorf(klderrors.HelperStrToAddressRequiredField, desc)
 		return
 	}
 	if !strings.HasPrefix(strAddr, "0x") {
 		strAddr = "0x" + strAddr
 	}
 	if !common.IsHexAddress(strAddr) {
-		err = fmt.Errorf("Supplied value for '%s' is not a valid hex address", desc)
+		err = klderrors.Errorf(klderrors.HelperStrToAddressBadAddress, desc)
 		return
 	}
 	addr = common.HexToAddress(strAddr)

--- a/internal/kldutils/payloadutils.go
+++ b/internal/kldutils/payloadutils.go
@@ -16,12 +16,12 @@ package kldutils
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 
 	"github.com/icza/dyno"
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -35,11 +35,11 @@ const (
 func YAMLorJSONPayload(req *http.Request) (map[string]interface{}, error) {
 
 	if req.ContentLength > MaxPayloadSize {
-		return nil, fmt.Errorf("Message exceeds maximum allowable size")
+		return nil, klderrors.Errorf(klderrors.HelperYAMLorJSONPayloadTooLarge)
 	}
 	originalPayload, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to read input data: %s", err)
+		return nil, klderrors.Errorf(klderrors.HelperYAMLorJSONPayloadReadFailed, err)
 	}
 
 	// We support both YAML and JSON input.
@@ -68,7 +68,7 @@ func YAMLorJSONPayload(req *http.Request) (map[string]interface{}, error) {
 		yamlGenericPayload := make(map[interface{}]interface{})
 		err := yaml.Unmarshal(originalPayload, &yamlGenericPayload)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to parse as YAML or JSON: %s", err)
+			return nil, klderrors.Errorf(klderrors.HelperYAMLorJSONPayloadParseFailed, err)
 		}
 		msg = dyno.ConvertMapI2MapS(yamlGenericPayload).(map[string]interface{})
 	}

--- a/internal/kldutils/tlsutils.go
+++ b/internal/kldutils/tlsutils.go
@@ -17,9 +17,9 @@ package kldutils
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"io/ioutil"
 
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -36,7 +36,7 @@ type TLSConfig struct {
 func CreateTLSConfiguration(tlsConfig *TLSConfig) (t *tls.Config, err error) {
 
 	if !AllOrNoneReqd(tlsConfig.ClientCertsFile, tlsConfig.ClientKeyFile) {
-		err = fmt.Errorf("Client private key and certificate must both be provided for mutual auth")
+		err = klderrors.Errorf(klderrors.ConfigTLSCertOrKey)
 		return
 	}
 


### PR DESCRIPTION
- Use a consistent utility to construct errors
- Keep all of the error messages in a single location (Go code for now, extensible to i18n translation)