### PR TITLE
Subscriptions being created to a zero address, rather than wildcard

### DIFF
--- a/internal/kldcontracts/rest2eth.go
+++ b/internal/kldcontracts/rest2eth.go
@@ -320,7 +320,9 @@ func (r *rest2eth) resolveParams(res http.ResponseWriter, req *http.Request, par
 		r.restErrReply(res, req, err, 404)
 		return
 	}
-	c.addr = "0x" + c.addr
+	if c.addr != "" {
+		c.addr = "0x" + c.addr
+	}
 
 	// If we have a from, it needs to be a valid address
 	kldFrom := getKLDParam("from", req, false)


### PR DESCRIPTION
When subscribing on the base ABI `/abis/:abi_id/:event_name/subscribe` route, without an address in the path, the subscription is being incorrectly created against a zero address:

Example below created against a `Changed` event.
The `name` should instead show `*:Changed(address,int64,string,string)` for a wildcard subscription against any address.

This was introduced in #42 

```json
  {
    "created": "2020-03-19T22:46:45Z",
    "id": "sb-52191a62-f73b-4dbe-766c-0bf56be29e59",
    "path": "/subscriptions/sb-52191a62-f73b-4dbe-766c-0bf56be29e59",
    "name": "0x0000000000000000000000000000000000000000:Changed(address,int64,string,string)",
    "stream": "es-c5d0f31c-bcb5-4c86-6b68-e161e6d9c2fd",
    "filter": {
      "address": [
        "0x0000000000000000000000000000000000000000"
      ],
      "topics": [
        [
          "0x9cc76f31dd4253fe222c0bcccf929a17496fc4f64167bf8cd1910b9e16f5be0f"
        ]
      ]
    },
    "event": {
      "name": "Changed",
      "Inputs": [
        {
          "name": "from",
          "type": "address",
          "indexed": true
        },
        {
          "name": "aNumber",
          "type": "int64",
          "indexed": true
        },
        {
          "name": "indexedString",
          "type": "string",
          "indexed": true
        },
        {
          "name": "aMessage",
          "type": "string",
          "indexed": false
        }
      ],
      "Outputs": null
    },
    "fromBlock": "latest"
  }
```