### PR TITLE
Set subscription name before creating subscription info

### DIFF
--- a/internal/kldevents/submanager.go
+++ b/internal/kldevents/submanager.go
@@ -135,6 +135,10 @@ func (s *subscriptionMGR) AddSubscription(ctx context.Context, addr *kldbind.Add
 		Stream: streamID,
 	}
 	i.Path = SubPathPrefix + "/" + i.ID
+	// Set any user supplied a name for the subscription
+	if name != "" {
+		i.Name = name
+	}
 	// Check initial block number to subscribe from
 	if initialBlock == "" || initialBlock == FromBlockLatest {
 		i.FromBlock = FromBlockLatest


### PR DESCRIPTION
The name was getting dropped in the chain of calls. Set the name that
is passed down from the caller before creating the subscription info.

Ref: https://github.com/kaleido-io/ethconnect/issues/68
Fixes a bug introduced in https://github.com/kaleido-io/ethconnect/pull/71