### PR TITLE
Update EventStream (http PATCH)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ coverage: coverage.txt coverage.html
 clean: 
 		$(VGO) clean
 		rm -f coverage.txt
-		rm -f coverage.out
 		rm -f $(BINARY_NAME)
 		rm -f $(BINARY_UNIX)
 run:

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,14 @@ build:
 		$(VGO) build -ldflags "-X main.buildDate=`date -u +\"%Y-%m-%dT%H:%M:%SZ\"` -X main.buildVersion=$(BUILD_VERSION)" -tags=prod -o $(BINARY_NAME) -v
 coverage.txt: $(GOFILES)
 		$(VGO) test  ./... -cover -coverprofile=coverage.txt -covermode=atomic
+coverage.html:
+	    $(VGO) tool cover -html=coverage.txt
 test: coverage.txt
+coverage: coverage.txt coverage.html
 clean: 
 		$(VGO) clean
 		rm -f coverage.txt
+		rm -f coverage.out
 		rm -f $(BINARY_NAME)
 		rm -f $(BINARY_UNIX)
 run:

--- a/internal/kldcontracts/rest2eth_test.go
+++ b/internal/kldcontracts/rest2eth_test.go
@@ -127,14 +127,15 @@ func (m *mockRPC) CallContext(ctx context.Context, result interface{}, method st
 }
 
 type mockSubMgr struct {
-	err          error
-	sub          *kldevents.SubscriptionInfo
-	stream       *kldevents.StreamInfo
-	subs         []*kldevents.SubscriptionInfo
-	streams      []*kldevents.StreamInfo
-	suspended    bool
-	resumed      bool
-	capturedAddr *kldbind.Address
+	err             error
+	updateStreamErr error
+	sub             *kldevents.SubscriptionInfo
+	stream          *kldevents.StreamInfo
+	subs            []*kldevents.SubscriptionInfo
+	streams         []*kldevents.StreamInfo
+	suspended       bool
+	resumed         bool
+	capturedAddr    *kldbind.Address
 }
 
 func (m *mockSubMgr) Init() error { return m.err }
@@ -142,7 +143,7 @@ func (m *mockSubMgr) AddStream(ctx context.Context, spec *kldevents.StreamInfo) 
 	return spec, m.err
 }
 func (m *mockSubMgr) UpdateStream(ctx context.Context, id string, spec *kldevents.StreamInfo) (*kldevents.StreamInfo, error) {
-	return m.stream, m.err
+	return m.stream, m.updateStreamErr
 }
 func (m *mockSubMgr) Streams(ctx context.Context) []*kldevents.StreamInfo { return m.streams }
 func (m *mockSubMgr) StreamByID(ctx context.Context, id string) (*kldevents.StreamInfo, error) {

--- a/internal/kldcontracts/rest2eth_test.go
+++ b/internal/kldcontracts/rest2eth_test.go
@@ -141,6 +141,9 @@ func (m *mockSubMgr) Init() error { return m.err }
 func (m *mockSubMgr) AddStream(ctx context.Context, spec *kldevents.StreamInfo) (*kldevents.StreamInfo, error) {
 	return spec, m.err
 }
+func (m *mockSubMgr) UpdateStream(ctx context.Context, id string, spec *kldevents.StreamInfo) (*kldevents.StreamInfo, error) {
+	return m.stream, m.err
+}
 func (m *mockSubMgr) Streams(ctx context.Context) []*kldevents.StreamInfo { return m.streams }
 func (m *mockSubMgr) StreamByID(ctx context.Context, id string) (*kldevents.StreamInfo, error) {
 	return m.stream, m.err

--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -676,6 +676,10 @@ func (g *smartContractGW) updateStream(res http.ResponseWriter, req *http.Reques
 		return
 	}
 	newSpec, err := g.sm.UpdateStream(req.Context(), streamID, &spec)
+	if err != nil {
+		g.gatewayErrReply(res, req, err, 500)
+		return
+	}
 
 	status := 200
 	log.Infof("<-- %s %s [%d]", req.Method, req.URL, status)

--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -115,6 +115,7 @@ func (g *smartContractGW) AddRoutes(router *httprouter.Router) {
 	router.GET("/gateways/:gateway_lookup", g.getRemoteRegistrySwaggerOrABI)
 	router.GET("/g/:gateway_lookup", g.getRemoteRegistrySwaggerOrABI)
 	router.POST(kldevents.StreamPathPrefix, g.withEventsAuth(g.createStream))
+	router.PATCH(kldevents.StreamPathPrefix, g.withEventsAuth(g.updateStream))
 	router.GET(kldevents.StreamPathPrefix, g.withEventsAuth(g.listStreamsOrSubs))
 	router.GET(kldevents.SubPathPrefix, g.withEventsAuth(g.listStreamsOrSubs))
 	router.GET(kldevents.StreamPathPrefix+"/:id", g.withEventsAuth(g.getStreamOrSub))
@@ -644,6 +645,37 @@ func (g *smartContractGW) createStream(res http.ResponseWriter, req *http.Reques
 		g.gatewayErrReply(res, req, err, 400)
 		return
 	}
+
+	status := 200
+	log.Infof("<-- %s %s [%d]", req.Method, req.URL, status)
+	res.Header().Set("Content-Type", "application/json")
+	res.WriteHeader(status)
+	enc := json.NewEncoder(res)
+	enc.SetIndent("", "  ")
+	enc.Encode(&newSpec)
+}
+
+// updateStream updates a stream
+func (g *smartContractGW) updateStream(res http.ResponseWriter, req *http.Request, params httprouter.Params) {
+	log.Infof("--> %s %s", req.Method, req.URL)
+
+	if g.sm == nil {
+		g.gatewayErrReply(res, req, errors.New(errEventSupportMissing), 405)
+		return
+	}
+
+	streamID := params.ByName("id")
+	_, err := g.sm.StreamByID(req.Context(), streamID)
+	if err != nil {
+		g.gatewayErrReply(res, req, err, 404)
+		return
+	}
+	var spec kldevents.StreamInfo
+	if err := json.NewDecoder(req.Body).Decode(&spec); err != nil {
+		g.gatewayErrReply(res, req, klderrors.Errorf(klderrors.RESTGatewayEventStreamInvalid, err), 400)
+		return
+	}
+	newSpec, err := g.sm.UpdateStream(req.Context(), streamID, &spec)
 
 	status := 200
 	log.Infof("<-- %s %s [%d]", req.Method, req.URL, status)

--- a/internal/kldcontracts/smartcontractgw_test.go
+++ b/internal/kldcontracts/smartcontractgw_test.go
@@ -1698,6 +1698,26 @@ func TestUpdateStreamNotFoundError(t *testing.T) {
 	assert.Regexp("pop", resError.Message)
 }
 
+func TestUpdateStreamSubMgrError(t *testing.T) {
+	assert := assert.New(t)
+	spec := &kldevents.StreamInfo{Type: "webhook"}
+	b, _ := json.Marshal(spec)
+	req := httptest.NewRequest("PATCH", kldevents.StreamPathPrefix, bytes.NewReader(b))
+	res := httptest.NewRecorder()
+	s := &smartContractGW{}
+	s.sm = &mockSubMgr{
+		updateStreamErr: fmt.Errorf("pop"),
+		err:             nil,
+	}
+	r := &httprouter.Router{}
+	s.AddRoutes(r)
+	r.ServeHTTP(res, req)
+	var resError restErrMsg
+	json.NewDecoder(res.Body).Decode(&resError)
+	assert.Equal(500, res.Result().StatusCode)
+	assert.Regexp("pop", resError.Message)
+}
+
 func TestListStreamsNoSubMgr(t *testing.T) {
 	assert := assert.New(t)
 	res := testGWPath("GET", kldevents.StreamPathPrefix, nil, nil)

--- a/internal/kldcontracts/smartcontractgw_test.go
+++ b/internal/kldcontracts/smartcontractgw_test.go
@@ -1643,6 +1643,61 @@ func TestAddStreamSubMgrError(t *testing.T) {
 	assert.Regexp("pop", resError.Message)
 }
 
+func TestUpdateStreamNoSubMgr(t *testing.T) {
+	assert := assert.New(t)
+	res := testGWPath("PATCH", kldevents.StreamPathPrefix, nil, nil)
+	assert.Equal(405, res.Result().StatusCode)
+}
+
+func TestUpdateStreamOK(t *testing.T) {
+	assert := assert.New(t)
+	spec := &kldevents.StreamInfo{Type: "webhook", Name: "stream-new-name"}
+	b, _ := json.Marshal(spec)
+	req := httptest.NewRequest("PATCH", kldevents.StreamPathPrefix, bytes.NewReader(b))
+	res := httptest.NewRecorder()
+	s := &smartContractGW{}
+	s.sm = &mockSubMgr{}
+	r := &httprouter.Router{}
+	s.AddRoutes(r)
+	r.ServeHTTP(res, req)
+	var newSpec kldevents.StreamInfo
+	json.NewDecoder(res.Body).Decode(&newSpec)
+	assert.Equal(200, res.Result().StatusCode)
+	s.Shutdown()
+}
+
+func TestUpdateStreamBadData(t *testing.T) {
+	assert := assert.New(t)
+	req := httptest.NewRequest("PATCH", kldevents.StreamPathPrefix, bytes.NewReader([]byte(":bad json")))
+	res := httptest.NewRecorder()
+	s := &smartContractGW{}
+	s.sm = &mockSubMgr{}
+	r := &httprouter.Router{}
+	s.AddRoutes(r)
+	r.ServeHTTP(res, req)
+	var resError restErrMsg
+	json.NewDecoder(res.Body).Decode(&resError)
+	assert.Equal(400, res.Result().StatusCode)
+	assert.Regexp("Invalid event stream specification", resError.Message)
+}
+
+func TestUpdateStreamNotFoundError(t *testing.T) {
+	assert := assert.New(t)
+	spec := &kldevents.StreamInfo{Type: "webhook"}
+	b, _ := json.Marshal(spec)
+	req := httptest.NewRequest("PATCH", kldevents.StreamPathPrefix, bytes.NewReader(b))
+	res := httptest.NewRecorder()
+	s := &smartContractGW{}
+	s.sm = &mockSubMgr{err: fmt.Errorf("pop")}
+	r := &httprouter.Router{}
+	s.AddRoutes(r)
+	r.ServeHTTP(res, req)
+	var resError restErrMsg
+	json.NewDecoder(res.Body).Decode(&resError)
+	assert.Equal(404, res.Result().StatusCode)
+	assert.Regexp("pop", resError.Message)
+}
+
 func TestListStreamsNoSubMgr(t *testing.T) {
 	assert := assert.New(t)
 	res := testGWPath("GET", kldevents.StreamPathPrefix, nil, nil)
@@ -1681,12 +1736,12 @@ func TestListSubs(t *testing.T) {
 
 	mockSubMgr := &mockSubMgr{
 		subs: []*kldevents.SubscriptionInfo{
-			&kldevents.SubscriptionInfo{
+			{
 				TimeSorted: kldmessages.TimeSorted{
 					CreatedISO8601: time.Now().UTC().Format(time.RFC3339),
 				}, ID: "earlier",
 			},
-			&kldevents.SubscriptionInfo{
+			{
 				TimeSorted: kldmessages.TimeSorted{
 					CreatedISO8601: time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339),
 				}, ID: "later",

--- a/internal/kldevents/eventstream.go
+++ b/internal/kldevents/eventstream.go
@@ -80,7 +80,6 @@ type eventStream struct {
 	spec              *StreamInfo
 	eventStream       chan *eventData
 	stopped           bool
-	dispatcherDone    bool
 	processorDone     bool
 	pollingInterval   time.Duration
 	pollerDone        bool
@@ -375,9 +374,7 @@ func (a *eventStream) batchDispatcher() {
 	var currentBatch []*eventData
 	var batchStart time.Time
 	batchTimeout := time.Duration(a.spec.BatchTimeoutMS) * time.Millisecond
-	defer func() {
-		a.dispatcherDone = true
-	}()
+	defer a.updateWG.Done()
 	for {
 		// Wait for the next event - if we're in the middle of a batch, we
 		// need to cope with a timeout

--- a/internal/kldevents/eventstream.go
+++ b/internal/kldevents/eventstream.go
@@ -391,9 +391,11 @@ func (a *eventStream) processBatch(batchNumber uint64, events []*eventData) {
 		}
 	}
 
-	// Always decrement the in-flight count once we've processed
+	// decrement the in-flight count if we've processed (wouldn't have occurred if we were suspended or stopped)
 	a.batchCond.L.Lock()
-	a.inFlight -= uint64(len(events))
+	if processed {
+		a.inFlight -= uint64(len(events))
+	}
 	a.batchCond.L.Unlock()
 
 	// If we were suspended, do not ack the batch

--- a/internal/kldevents/eventstream_test.go
+++ b/internal/kldevents/eventstream_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/kaleido-io/ethconnect/internal/kldbind"
+	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	"github.com/kaleido-io/ethconnect/internal/kldeth"
 	"github.com/kaleido-io/ethconnect/internal/kldkvstore"
 	log "github.com/sirupsen/logrus"
@@ -76,7 +77,7 @@ func testEvent(subID string) *eventData {
 	}
 }
 
-func newTestStreamForBatching(spec *StreamInfo, status ...int) (*subscriptionMGR, *eventStream, *httptest.Server, chan []*eventData) {
+func newTestStreamForBatching(spec *StreamInfo, db kldkvstore.KVStore, status ...int) (*subscriptionMGR, *eventStream, *httptest.Server, chan []*eventData) {
 	mux := http.NewServeMux()
 	eventStream := make(chan []*eventData)
 	count := 0
@@ -98,6 +99,9 @@ func newTestStreamForBatching(spec *StreamInfo, status ...int) (*subscriptionMGR
 	sm := newTestSubscriptionManager()
 	sm.config().WebhooksAllowPrivateIPs = true
 	sm.config().EventPollingIntervalSec = 0
+	if db != nil {
+		sm.db = db
+	}
 	ctx := context.Background()
 	stream, _ := sm.AddStream(ctx, spec)
 	return sm, sm.streams[stream.ID], svr, eventStream
@@ -110,7 +114,7 @@ func TestBatchTimeout(t *testing.T) {
 			BatchSize:      10,
 			BatchTimeoutMS: 50,
 			Webhook:        &webhookAction{},
-		}, 200)
+		}, nil, 200)
 	defer close(eventStream)
 	defer svr.Close()
 	defer stream.stop()
@@ -156,7 +160,7 @@ func TestStopDuringTimeout(t *testing.T) {
 			BatchSize:      10,
 			BatchTimeoutMS: 2000,
 			Webhook:        &webhookAction{},
-		}, 200)
+		}, nil, 200)
 	defer close(eventStream)
 	defer svr.Close()
 
@@ -174,7 +178,7 @@ func TestBatchSizeCap(t *testing.T) {
 		&StreamInfo{
 			BatchSize: 10000000,
 			Webhook:   &webhookAction{},
-		}, 200)
+		}, nil, 200)
 	defer close(eventStream)
 	defer svr.Close()
 	defer stream.stop()
@@ -189,7 +193,7 @@ func TestStreamName(t *testing.T) {
 		&StreamInfo{
 			Name:    "testStream",
 			Webhook: &webhookAction{},
-		}, 200)
+		}, nil, 200)
 	defer close(eventStream)
 	defer svr.Close()
 	defer stream.stop()
@@ -205,7 +209,7 @@ func TestBlockingBehavior(t *testing.T) {
 			Webhook:              &webhookAction{},
 			ErrorHandling:        ErrorHandlingBlock,
 			BlockedRetryDelaySec: 1,
-		}, 404)
+		}, nil, 404)
 	defer close(eventStream)
 	defer svr.Close()
 	defer stream.stop()
@@ -230,7 +234,7 @@ func TestSkippingBehavior(t *testing.T) {
 			Webhook:              &webhookAction{},
 			ErrorHandling:        ErrorHandlingSkip,
 			BlockedRetryDelaySec: 1,
-		}, 404 /* fail the requests */)
+		}, nil, 404 /* fail the requests */)
 	defer close(eventStream)
 	defer svr.Close()
 	defer stream.stop()
@@ -259,7 +263,7 @@ func TestBackoffRetry(t *testing.T) {
 			ErrorHandling:        ErrorHandlingBlock,
 			RetryTimeoutSec:      1,
 			BlockedRetryDelaySec: 1,
-		}, 404, 500, 503, 504, 200)
+		}, nil, 404, 500, 503, 504, 200)
 	defer close(eventStream)
 	defer svr.Close()
 	defer stream.stop()
@@ -294,7 +298,7 @@ func TestBlockedAddresses(t *testing.T) {
 		&StreamInfo{
 			ErrorHandling: ErrorHandlingBlock,
 			Webhook:       &webhookAction{},
-		}, 200)
+		}, nil, 200)
 	defer close(eventStream)
 	defer svr.Close()
 	defer stream.stop()
@@ -317,7 +321,7 @@ func TestBadDNSName(t *testing.T) {
 		&StreamInfo{
 			ErrorHandling: ErrorHandlingSkip,
 			Webhook:       &webhookAction{},
-		}, 200)
+		}, nil, 200)
 	defer close(eventStream)
 	defer svr.Close()
 	defer stream.stop()
@@ -342,7 +346,7 @@ func TestBuildup(t *testing.T) {
 		&StreamInfo{
 			ErrorHandling: ErrorHandlingBlock,
 			Webhook:       &webhookAction{},
-		}, 200)
+		}, nil, 200)
 	defer close(eventStream)
 	defer svr.Close()
 	defer stream.stop()
@@ -429,12 +433,12 @@ func TestProcessEventsEnd2End(t *testing.T) {
 	dir := tempdir(t)
 	defer cleanup(t, dir)
 
+	db, _ := kldkvstore.NewLDBKeyValueStore(dir)
 	sm, stream, svr, eventStream := newTestStreamForBatching(
 		&StreamInfo{
 			BatchSize: 1,
 			Webhook:   &webhookAction{},
-		}, 200)
-	sm.db, _ = kldkvstore.NewLDBKeyValueStore(dir)
+		}, db, 200)
 	defer svr.Close()
 
 	s := setupTestSubscription(assert, sm, stream, "mySubName")
@@ -478,7 +482,7 @@ func TestCheckpointRecovery(t *testing.T) {
 		&StreamInfo{
 			ErrorHandling: ErrorHandlingBlock,
 			Webhook:       &webhookAction{},
-		}, 200)
+		}, nil, 200)
 	defer close(eventStream)
 	defer svr.Close()
 	defer stream.stop()
@@ -541,7 +545,7 @@ func TestWithoutCheckpointRecovery(t *testing.T) {
 		&StreamInfo{
 			ErrorHandling: ErrorHandlingBlock,
 			Webhook:       &webhookAction{},
-		}, 200)
+		}, nil, 200)
 	defer close(eventStream)
 	defer svr.Close()
 	defer stream.stop()
@@ -582,7 +586,7 @@ func TestMarkStaleOnError(t *testing.T) {
 		&StreamInfo{
 			ErrorHandling: ErrorHandlingBlock,
 			Webhook:       &webhookAction{},
-		}, 200)
+		}, nil, 200)
 	defer close(eventStream)
 	defer svr.Close()
 	defer stream.stop()
@@ -613,7 +617,7 @@ func TestStoreCheckpointLoadError(t *testing.T) {
 		&StreamInfo{
 			ErrorHandling: ErrorHandlingBlock,
 			Webhook:       &webhookAction{},
-		}, 200)
+		}, nil, 200)
 	mockKV := kldkvstore.NewMockKV(fmt.Errorf("pop"))
 	sm.db = mockKV
 	defer close(eventStream)
@@ -636,10 +640,9 @@ func TestStoreCheckpointStoreError(t *testing.T) {
 		&StreamInfo{
 			ErrorHandling: ErrorHandlingBlock,
 			Webhook:       &webhookAction{},
-		}, 200)
+		}, nil, 200)
 	mockKV := kldkvstore.NewMockKV(nil)
 	mockKV.StoreErr = fmt.Errorf("pop")
-	sm.db = mockKV
 	defer close(eventStream)
 	defer svr.Close()
 	defer stream.stop()
@@ -666,7 +669,7 @@ func TestProcessBatchEmptyArray(t *testing.T) {
 		&StreamInfo{
 			ErrorHandling: ErrorHandlingBlock,
 			Webhook:       &webhookAction{},
-		}, 200)
+		}, nil, 200)
 	mockKV := kldkvstore.NewMockKV(nil)
 	mockKV.StoreErr = fmt.Errorf("pop")
 	sm.db = mockKV
@@ -675,4 +678,153 @@ func TestProcessBatchEmptyArray(t *testing.T) {
 	defer stream.stop()
 
 	stream.processBatch(0, []*eventData{})
+}
+
+func TestUpdateStream(t *testing.T) {
+	assert := assert.New(t)
+	dir := tempdir(t)
+	defer cleanup(t, dir)
+
+	db, _ := kldkvstore.NewLDBKeyValueStore(dir)
+	sm, stream, svr, eventStream := newTestStreamForBatching(
+		&StreamInfo{
+			ErrorHandling: ErrorHandlingBlock,
+			Webhook:       &webhookAction{},
+		}, db, 200)
+	defer svr.Close()
+
+	s := setupTestSubscription(assert, sm, stream, "mySubName")
+	assert.Equal("mySubName", s.Name)
+
+	// We expect three events to be sent to the webhook
+	// With the default batch size of 1, that means three separate requests
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		<-eventStream
+		<-eventStream
+		<-eventStream
+		wg.Done()
+	}()
+	wg.Wait()
+
+	ctx := context.Background()
+	headers := make(map[string]string)
+	headers["test-h1"] = "val1"
+	updateSpec := &StreamInfo{
+		BatchSize:            10,
+		BatchTimeoutMS:       1234,
+		BlockedRetryDelaySec: 27,
+		ErrorHandling:        ErrorHandlingBlock,
+		Name:                 "new-name",
+		Webhook: &webhookAction{
+			URL:               "http://foo.url",
+			Headers:           headers,
+			TLSkipHostVerify:  true,
+			RequestTimeoutSec: 0,
+		},
+	}
+	updatedStream, err := sm.UpdateStream(ctx, stream.spec.ID, updateSpec)
+	assert.Equal(updatedStream.Name, "new-name")
+	assert.Equal(updatedStream.BatchSize, uint64(10))
+	assert.Equal(updatedStream.BatchTimeoutMS, uint64(1234))
+	assert.Equal(updatedStream.BlockedRetryDelaySec, uint64(27))
+	assert.Equal(updatedStream.ErrorHandling, ErrorHandlingBlock)
+	assert.Equal(updatedStream.Webhook.URL, "http://foo.url")
+	assert.Equal(updatedStream.Webhook.Headers["test-h1"], "val1")
+	err = sm.DeleteSubscription(ctx, s.ID)
+	assert.NoError(err)
+	err = sm.DeleteStream(ctx, stream.spec.ID)
+	assert.NoError(err)
+	sm.Close()
+}
+
+func TestUpdateStreamMissingWebhookURL(t *testing.T) {
+	assert := assert.New(t)
+	dir := tempdir(t)
+	defer cleanup(t, dir)
+
+	db, _ := kldkvstore.NewLDBKeyValueStore(dir)
+	sm, stream, svr, eventStream := newTestStreamForBatching(
+		&StreamInfo{
+			ErrorHandling: ErrorHandlingBlock,
+			Webhook:       &webhookAction{},
+		}, db, 200)
+	defer svr.Close()
+
+	s := setupTestSubscription(assert, sm, stream, "mySubName")
+	assert.Equal("mySubName", s.Name)
+
+	// We expect three events to be sent to the webhook
+	// With the default batch size of 1, that means three separate requests
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		<-eventStream
+		<-eventStream
+		<-eventStream
+		wg.Done()
+	}()
+	wg.Wait()
+
+	ctx := context.Background()
+	updateSpec := &StreamInfo{
+		Webhook: &webhookAction{
+			URL:               "",
+			TLSkipHostVerify:  true,
+			RequestTimeoutSec: 5,
+		},
+	}
+	_, err := sm.UpdateStream(ctx, stream.spec.ID, updateSpec)
+	assert.EqualError(err, klderrors.EventStreamsWebhookNoURL)
+	err = sm.DeleteSubscription(ctx, s.ID)
+	assert.NoError(err)
+	err = sm.DeleteStream(ctx, stream.spec.ID)
+	assert.NoError(err)
+	sm.Close()
+}
+
+func TestUpdateStreamNoWebhookURL(t *testing.T) {
+	assert := assert.New(t)
+	dir := tempdir(t)
+	defer cleanup(t, dir)
+
+	db, _ := kldkvstore.NewLDBKeyValueStore(dir)
+	sm, stream, svr, eventStream := newTestStreamForBatching(
+		&StreamInfo{
+			ErrorHandling: ErrorHandlingBlock,
+			Webhook:       &webhookAction{},
+		}, db, 200)
+	defer svr.Close()
+
+	s := setupTestSubscription(assert, sm, stream, "mySubName")
+	assert.Equal("mySubName", s.Name)
+
+	// We expect three events to be sent to the webhook
+	// With the default batch size of 1, that means three separate requests
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		<-eventStream
+		<-eventStream
+		<-eventStream
+		wg.Done()
+	}()
+	wg.Wait()
+
+	ctx := context.Background()
+	updateSpec := &StreamInfo{
+		Webhook: &webhookAction{
+			URL:               ":bad",
+			TLSkipHostVerify:  true,
+			RequestTimeoutSec: 5,
+		},
+	}
+	_, err := sm.UpdateStream(ctx, stream.spec.ID, updateSpec)
+	assert.EqualError(err, klderrors.EventStreamsWebhookInvalidURL)
+	err = sm.DeleteSubscription(ctx, s.ID)
+	assert.NoError(err)
+	err = sm.DeleteStream(ctx, stream.spec.ID)
+	assert.NoError(err)
+	sm.Close()
 }

--- a/internal/kldevents/eventstream_test.go
+++ b/internal/kldevents/eventstream_test.go
@@ -169,7 +169,6 @@ func TestStopDuringTimeout(t *testing.T) {
 	stream.stop()
 	time.Sleep(10 * time.Millisecond)
 	assert.True(stream.processorDone)
-	assert.True(stream.dispatcherDone)
 }
 
 func TestBatchSizeCap(t *testing.T) {

--- a/internal/kldevents/submanager.go
+++ b/internal/kldevents/submanager.go
@@ -49,6 +49,7 @@ type SubscriptionManager interface {
 	AddStream(ctx context.Context, spec *StreamInfo) (*StreamInfo, error)
 	Streams(ctx context.Context) []*StreamInfo
 	StreamByID(ctx context.Context, id string) (*StreamInfo, error)
+	UpdateStream(ctx context.Context, id string, spec *StreamInfo) (*StreamInfo, error)
 	SuspendStream(ctx context.Context, id string) error
 	ResumeStream(ctx context.Context, id string) error
 	DeleteStream(ctx context.Context, id string) error
@@ -217,6 +218,19 @@ func (s *subscriptionMGR) AddStream(ctx context.Context, spec *StreamInfo) (*Str
 	}
 	s.streams[stream.spec.ID] = stream
 	return s.storeStream(stream.spec)
+}
+
+// UpdateStream updates an existing stream
+func (s *subscriptionMGR) UpdateStream(ctx context.Context, id string, spec *StreamInfo) (*StreamInfo, error) {
+	stream, err := s.streamByID(id)
+	if err != nil {
+		return nil, err
+	}
+	updatedSpec, err := stream.update(spec)
+	if err != nil {
+		return nil, err
+	}
+	return s.storeStream(updatedSpec)
 }
 
 func (s *subscriptionMGR) storeStream(spec *StreamInfo) (*StreamInfo, error) {


### PR DESCRIPTION
* All fields in the event stream except the ID are allowed to be updated
* Event streams could be updated while batches of events are currently being processed. The existing logic around concurrent handling of batch processing of events and any pause/stopping of event streams ensures that batch processing exits as soon as a pause/stop event is detected. This PR adds an additional empty struct channel that can be closed to signal that the update of the stream is underway. The handler go routines select on the `updateInterrupt` ch so that they are woken up when the update is underway and can exit. The actual update to the event stream spec is performed after the go routines exit. Subsequently, a fresh round of event handler go routines is started.
* Fixes a bug that was incorrectly updating inflight count even if stream is suspended/stopped. Check that we processed the event before decrementing the in-flight counter
* Adds command to generate html for coverage

Addresses one of the items in: https://github.com/kaleido-io/ethconnect/issues/68