### PR TITLE
Track and use highest nonce among in-flight transactions

### DIFF
--- a/internal/kldtx/hdwallet_test.go
+++ b/internal/kldtx/hdwallet_test.go
@@ -71,6 +71,7 @@ func TestHDWalletSignOK(t *testing.T) {
 	s, err := hd.SignerFor(hdr)
 	assert.NoError(err)
 
+	assert.Equal(s.Type(), "HD Wallet")
 	assert.Equal(addr.String(), s.Address())
 
 	tx := types.NewContractCreation(12345, big.NewInt(0), 0, big.NewInt(0), []byte("hello world"))

--- a/internal/kldtx/txnprocessor.go
+++ b/internal/kldtx/txnprocessor.go
@@ -245,7 +245,7 @@ func (p *txnProcessor) addInflightWrapper(txnContext TxnContext, msg *kldmessage
 	if !nodeAssignNonce && suppliedNonce == "" {
 		// Check the currently inflight txns to see if we have a high nonce to use without
 		// needing to query the node to find the highest nonce.
-		if exists && len(inflightForAddr.txnsInFlight) > 0 {
+		if exists {
 			highestNonce = inflightForAddr.highestNonce
 		}
 	}

--- a/internal/kldtx/txnprocessor.go
+++ b/internal/kldtx/txnprocessor.go
@@ -317,6 +317,10 @@ func (p *txnProcessor) cancelInFlight(inflight *inflightTxn, gapPotential bool) 
 			}
 		}
 		after = len(inflightForAddr.txnsInFlight)
+		// clear the entry for inflight.from when there are no in-flight txns
+		if after == 0 {
+			delete(p.inflightTxns, inflight.from)
+		}
 		// Check the transactions that are left, to see if any nonce is higher
 		if gapPotential && !inflight.nodeAssignNonce {
 			for _, alreadyInflight := range inflightForAddr.txnsInFlight {

--- a/internal/kldtx/txnprocessor.go
+++ b/internal/kldtx/txnprocessor.go
@@ -86,10 +86,15 @@ type TxnProcessorConf struct {
 	HDWalletConf       HDWalletConf    `json:"hdWallet"`
 }
 
+type inflightTxnState struct {
+	txnsInFlight []*inflightTxn
+	highestNonce int64
+}
+
 type txnProcessor struct {
 	maxTXWaitTime      time.Duration
 	inflightTxnsLock   *sync.Mutex
-	inflightTxns       map[string][]*inflightTxn
+	inflightTxns       map[string]*inflightTxnState
 	inflightTxnDelayer TxnDelayTracker
 	rpc                kldeth.RPCClient
 	addressBook        AddressBook
@@ -106,7 +111,7 @@ func NewTxnProcessor(conf *TxnProcessorConf, rpcConf *kldeth.RPCConf) TxnProcess
 	}
 	p := &txnProcessor{
 		inflightTxnsLock:   &sync.Mutex{},
-		inflightTxns:       make(map[string][]*inflightTxn),
+		inflightTxns:       make(map[string]*inflightTxnState),
 		inflightTxnDelayer: NewTxnDelayTracker(),
 		conf:               conf,
 		rpcConf:            rpcConf,
@@ -230,16 +235,18 @@ func (p *txnProcessor) addInflightWrapper(txnContext TxnContext, msg *kldmessage
 	var highestNonce int64 = -1
 	suppliedNonce := msg.Nonce
 	inflightForAddr, exists := p.inflightTxns[inflight.from]
+	// Add the inflight transaction to our tracking structure
+	if !exists {
+		p.inflightTxns[inflight.from] = &inflightTxnState{}
+		inflightForAddr = p.inflightTxns[inflight.from]
+		inflightForAddr.txnsInFlight = []*inflightTxn{}
+	}
 
 	if !nodeAssignNonce && suppliedNonce == "" {
 		// Check the currently inflight txns to see if we have a high nonce to use without
 		// needing to query the node to find the highest nonce.
-		if exists {
-			for _, alreadyInflight := range inflightForAddr {
-				if alreadyInflight.nonce > highestNonce {
-					highestNonce = alreadyInflight.nonce
-				}
-			}
+		if exists && len(inflightForAddr.txnsInFlight) > 0 {
+			highestNonce = inflightForAddr.highestNonce
 		}
 	}
 
@@ -264,8 +271,9 @@ func (p *txnProcessor) addInflightWrapper(txnContext TxnContext, msg *kldmessage
 		}
 		fromNode = true
 	} else if highestNonce >= 0 {
-		// If we found a nonce in-flight in memory, return one higher.
+		// If we found a nonce in-flight in memory, store & return one higher.
 		inflight.nonce = highestNonce + 1
+		inflightForAddr.highestNonce = inflight.nonce
 	} else if nodeAssignNonce {
 		// We've been asked to defer to the node for signing, and are not performing HD Wallet signing
 		inflight.nodeAssignNonce = true
@@ -277,21 +285,18 @@ func (p *txnProcessor) addInflightWrapper(txnContext TxnContext, msg *kldmessage
 		// (or if gas price is being varied by the submitter the potential of
 		// overwriting a transaction)
 		if inflight.nonce, err = kldeth.GetTransactionCount(txnContext.Context(), p.rpc, &from, "pending"); err != nil {
+			inflightForAddr.highestNonce = inflight.nonce // store the nonce in our inflight txns state
 			p.inflightTxnsLock.Unlock()
 			return
 		}
 		fromNode = true
 	}
 
-	// Add the inflight transaction to our tracking structure
-	if !exists {
-		inflightForAddr = []*inflightTxn{}
-	}
-	before := len(inflightForAddr)
-	p.inflightTxns[inflight.from] = append(inflightForAddr, inflight)
+	before := len(inflightForAddr.txnsInFlight)
+	inflightForAddr.txnsInFlight = append(inflightForAddr.txnsInFlight, inflight)
 	inflight.initialWaitDelay = p.inflightTxnDelayer.GetInitialDelay() // Must call under lock
 
-	// Clear lock beofre logging
+	// Clear lock before logging
 	p.inflightTxnsLock.Unlock()
 
 	log.Infof("In-flight %d added. nonce=%d addr=%s before=%d (node=%t)", inflight.id, inflight.nonce, inflight.from, before, fromNode)
@@ -304,18 +309,17 @@ func (p *txnProcessor) cancelInFlight(inflight *inflightTxn, gapPotential bool) 
 	var higherNonceInflight = int64(-1)
 	p.inflightTxnsLock.Lock()
 	if inflightForAddr, exists := p.inflightTxns[inflight.from]; exists {
-		before = len(inflightForAddr)
-		for idx, alreadyInflight := range inflightForAddr {
+		before = len(inflightForAddr.txnsInFlight)
+		for idx, alreadyInflight := range inflightForAddr.txnsInFlight {
 			if alreadyInflight.id == inflight.id {
-				inflightForAddr = append(inflightForAddr[0:idx], inflightForAddr[idx+1:]...)
-				p.inflightTxns[inflight.from] = inflightForAddr
+				p.inflightTxns[inflight.from].txnsInFlight = append(inflightForAddr.txnsInFlight[0:idx], inflightForAddr.txnsInFlight[idx+1:]...)
 				break
 			}
 		}
-		after = len(inflightForAddr)
+		after = len(inflightForAddr.txnsInFlight)
 		// Check the transactions that are left, to see if any nonce is higher
 		if gapPotential && !inflight.nodeAssignNonce {
-			for _, alreadyInflight := range inflightForAddr {
+			for _, alreadyInflight := range inflightForAddr.txnsInFlight {
 				if alreadyInflight.nonce > inflight.nonce && alreadyInflight.nonce > higherNonceInflight {
 					higherNonceInflight = alreadyInflight.nonce
 				}

--- a/internal/kldtx/txnprocessor_test.go
+++ b/internal/kldtx/txnprocessor_test.go
@@ -320,6 +320,8 @@ func TestOnDeployContractMessageGoodTxnMined(t *testing.T) {
 	txnProcessor.maxTXWaitTime = 250 * time.Millisecond // ... but fail asap for this test
 
 	txnProcessor.OnMessage(testTxnContext)
+	// the txn should be present in the in-flight list
+	assert.Equal(len(txnProcessor.inflightTxns[strings.ToLower(testFromAddr)].txnsInFlight), 1)
 	for inMap := false; !inMap; _, inMap = txnProcessor.inflightTxns[strings.ToLower(testFromAddr)] {
 		time.Sleep(1 * time.Millisecond)
 	}
@@ -337,6 +339,9 @@ func TestOnDeployContractMessageGoodTxnMined(t *testing.T) {
 	var replyMsgMap map[string]interface{}
 	json.Unmarshal(replyMsgBytes, &replyMsgMap)
 
+	// the map of in-flight txns must not contain an entry for testFromAddr
+	_, exists := txnProcessor.inflightTxns[strings.ToLower(testFromAddr)]
+	assert.Equal(exists, false)
 	assert.Equal("0x6e710868fd2d0ac1f141ba3f0cd569e38ce1999d8f39518ee7633d2b9a7122af", replyMsgMap["blockHash"])
 	assert.Equal("12345", replyMsgMap["blockNumber"])
 	assert.Equal("0x28a62cb478a3c3d4daad84f1148ea16cd1a66f37", replyMsgMap["contractAddress"])


### PR DESCRIPTION
* The current logic for assigning nonce runs through the in-flight list to
determine the maximum and assigns one higher
* When a batch of transactions are in-flight and a receipt for the txn
with highest nonce is received before all others which have lower
nonces, the txn is cleared from the in-flight list. The next
transaction from the same account is re-assigned the nonce that was used
by the cleared transaction, which results in a "nonce too low" error.
This PR introduces a `highestNonce` that is maintained for the in-flight
batch and is updated whenever a new transaction is added. This way, any
transactions which are cleared do not negatively impact the calculation
of the nonce when the next transaction is processed.