### PR TITLE
Add missing arg to eth_getBlockByNumber rpc call

### DIFF
--- a/internal/kldevents/subscription.go
+++ b/internal/kldevents/subscription.go
@@ -184,7 +184,8 @@ func (s *subscription) getEventTimestamp(ctx context.Context, l *logEntry) {
 	rpcMethod := "eth_getBlockByNumber"
 
 	var hdr kldbind.Header
-	if err := s.rpc.CallContext(ctx, &hdr, rpcMethod, blockNumber); err != nil {
+	// 2nd parameter (false) indicates it is sufficient to retrieve only hashes of tx objects
+	if err := s.rpc.CallContext(ctx, &hdr, rpcMethod, blockNumber, false); err != nil {
 		log.Errorf("Unable to retrieve block[%s] timestamp: %s", blockNumber, err)
 		l.Timestamp = 0 // set to 0, we were not able to retrieve the timestamp.
 		return


### PR DESCRIPTION
2nd (mandatory) arg indicates whether to retrieve only tx hashes or
full txn objects

ref: https://eth.wiki/json-rpc/API
