### PR TITLE
ABIEncoderV2 support for struct (tuple) function input/output

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,7 @@ github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyex
 github.com/mholt/archiver v3.1.1+incompatible h1:1dCVxuqs0dJseYEhi5pl7MYPH9zDa1wBi7mF09cbNkU=
 github.com/mholt/archiver v3.1.1+incompatible/go.mod h1:Dh2dOXnSdiLxRiPoVfIr/fI1TwETms9B8CTWfeh7ROU=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/kldauth/auth_test.go
+++ b/internal/kldauth/auth_test.go
@@ -50,7 +50,7 @@ func TestAccessToken(t *testing.T) {
 	assert.Equal(nil, GetAuthContext(context.Background()))
 	assert.Equal("", GetAccessToken(context.Background()))
 
-	ctx, err = WithAuthContext(context.Background(), "badone")
+	_, err = WithAuthContext(context.Background(), "badone")
 	assert.EqualError(err, "badness")
 
 	RegisterSecurityModule(nil)

--- a/internal/kldcontracts/rest2eth.go
+++ b/internal/kldcontracts/rest2eth.go
@@ -316,7 +316,7 @@ func (r *rest2eth) resolveParams(res http.ResponseWriter, req *http.Request, par
 
 	// If we have an address, it must be valid
 	if c.addr != "" && !validAddress {
-		log.Errorf("Invalid to addres: '%s'", params.ByName("address"))
+		log.Errorf("Invalid to address: '%s'", params.ByName("address"))
 		err = klderrors.Errorf(klderrors.RESTGatewayInvalidToAddress)
 		r.restErrReply(res, req, err, 404)
 		return

--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -1222,7 +1222,7 @@ func (g *smartContractGW) writeHTMLForUI(prefix, id, from string, isGateway, fac
 	html := `<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
 <head>
-  <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 charecters -->
+  <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 characters -->
   <script src="https://unpkg.com/rapidoc@7.1.0/dist/rapidoc-min.js"></script>
 </head>
 <body>
@@ -1250,7 +1250,7 @@ func (g *smartContractGW) writeHTMLForUI(prefix, id, from string, isGateway, fac
         <p><a href="#quickstart" style="text-decoration: none" onclick="document.getElementById('kaleido-quickstart-header').style.display = 'block'; this.style.display = 'none'; return false;">Show additional instructions</a></p>
         <div id="kaleido-quickstart-header" style="display: none;">
           <ul>
-            <li>Authorization with Kaleido Applicaiton Credentials has already been performed when loading this page, and is passed to API calls by your browser.</code>
+            <li>Authorization with Kaleido Application Credentials has already been performed when loading this page, and is passed to API calls by your browser.</code>
             <li><code>POST</code> actions against Solidity methods will <b>write to the chain</b> unless <code>kld-call</code> is set, or the method is marked <code>[read-only]</code>
             <ul>
               <li>When <code>kld-sync</code> is set, the response will not be returned until the transaction is mined <b>taking a few seconds</b></li>

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -333,27 +333,29 @@ const (
 	// TransactionSendBadGasPrice a user-supplied gasPrice (eth to pay for each unit of gas spent) string in the JSON input cannot be processed
 	TransactionSendBadGasPrice = "Converting supplied 'gasPrice' to big integer"
 	// TransactionSendInputTypeBadNumber the input JSON value supplied for a method parameter cannot be converted to a number
-	TransactionSendInputTypeBadNumber = "Method '%s' param %d: Could not be converted to a number"
+	TransactionSendInputTypeBadNumber = "Method '%s' param %s: Could not be converted to a number"
 	// TransactionSendInputTypeBadJSONTypeForNumber the input JSON value supplied for a method parameter was not a number or a string, and needs to be converted to a number
-	TransactionSendInputTypeBadJSONTypeForNumber = "Method '%s' param %d is a %s: Must supply a number or a string"
+	TransactionSendInputTypeBadJSONTypeForNumber = "Method '%s' param %s is a %s: Must supply a number or a string (supplied=%s)"
 	// TransactionSendInputTypeBadJSONTypeForArray the input JSON value supplied for a method parameter was not compatible with coercion to an array
-	TransactionSendInputTypeBadJSONTypeForArray = "Method '%s' param %d is a %s: Must supply an array"
+	TransactionSendInputTypeBadJSONTypeForArray = "Method '%s' param %s is a %s: Must supply an array (supplied=%s)"
 	// TransactionSendInputTypeBadNull the input JSON value supplied was null
-	TransactionSendInputTypeBadNull = "Method '%s' param %d: Cannot supply a null value"
+	TransactionSendInputTypeBadNull = "Method '%s' param %s: Cannot supply a null value"
 	// TransactionSendInputTypeBadJSONTypeForBoolean the input JSON value supplied for a method parameter was not compatible with coercion to a boolean
-	TransactionSendInputTypeBadJSONTypeForBoolean = "Method '%s' param %d is a %s: Must supply a boolean or a string"
+	TransactionSendInputTypeBadJSONTypeForBoolean = "Method '%s' param %s is a %s: Must supply a boolean or a string (supplied=%s)"
 	// TransactionSendInputTypeBadJSONTypeForString the input JSON value supplied for a method parameter was not compatible with coercion to a boolean
-	TransactionSendInputTypeBadJSONTypeForString = "Method '%s' param %d: Must supply a string"
+	TransactionSendInputTypeBadJSONTypeForString = "Method '%s' param %s: Must supply a string (supplied=%s)"
 	// TransactionSendInputTypeAddress the input JSON value supplied for a method parameter couldn't be parsed as an eth address
-	TransactionSendInputTypeAddress = "Method '%s' param %d: Could not be converted to a hex address"
+	TransactionSendInputTypeAddress = "Method '%s' param %s: Could not be converted to a hex address (supplied=%s)"
 	// TransactionSendInputTypeBadJSONTypeForAddress the input JSON value supplied for a method parameter was not compatible with coercion to an eth address
-	TransactionSendInputTypeBadJSONTypeForAddress = "Method '%s' param %d is a %s: Must supply a hex address string"
+	TransactionSendInputTypeBadJSONTypeForAddress = "Method '%s' param %s is a %s: Must supply a hex address string (supplied=%s)"
 	// TransactionSendInputTypeBadJSONTypeInNumericArray one of the entries inside of a numeric array, is not valid as a number
-	TransactionSendInputTypeBadJSONTypeInNumericArray = "Method '%s' param %d is a %s: Invalid entry in number array at index %d (%s)"
+	TransactionSendInputTypeBadJSONTypeInNumericArray = "Method '%s' param %s is a %s: Invalid entry in number array at index %d (%s)"
 	// TransactionSendInputTypeBadByteOutsideRange one of the entries inside of a byte array, is a number outside the range for bytes
-	TransactionSendInputTypeBadByteOutsideRange = "Method '%s' param %d is a %s: Invalid number - outside of range for byte"
+	TransactionSendInputTypeBadByteOutsideRange = "Method '%s' param %s is a %s: Invalid number - outside of range for byte"
 	// TransactionSendInputTypeBadJSONTypeForBytes one of the entries inside of a byte array, is a number outside the range for bytes
-	TransactionSendInputTypeBadJSONTypeForBytes = "Method '%s' param %d is a %s: Must supply a hex string, or number array"
+	TransactionSendInputTypeBadJSONTypeForBytes = "Method '%s' param %s is a %s: Must supply a hex string, or number array"
+  // TransactionSendInputTypeBadJSONTypeForTuple if we are provided a non object input on the JSON for a struct (tuple)
+  TransactionSendInputTypeBadJSONTypeForTuple = "Method '%s' param %s is a %s: Must supply an object (supplied=%s)"
 	// TransactionSendInputTypeNotSupported did not know how to handle this type - enhancement required
 	TransactionSendInputTypeNotSupported = "Type '%s' is not yet supported"
 	// TransactionSendInputCountMismatch wrong number of args supplied according to the ABI
@@ -367,7 +369,9 @@ const (
 	// TransactionSendMsgTypeUnknown we got a JSON message into the core processor (from Kafka, Webhooks etc.) that we don't understand
 	TransactionSendMsgTypeUnknown = "Unknown message type '%s'"
 	// TransactionSendInputTooManyParams more parameters provided than specified on ABI
-	TransactionSendInputTooManyParams = "Supplied %d paramters for ABI that supports %d"
+  TransactionSendInputTooManyParams = "Supplied %d paramters for ABI that supports %d"
+  // TransactionSendInputNotAssignable if we end up in a situation where the generated type cannot be assiend
+  TransactionSendInputNotAssignable = "Method %s param %s: supplied value '%+v' could not be assigned to '%s' field"
 
 	// TransactionSendReceiptCheckError we continually had bad RCs back from the node while trying to check for the receipt up to the timeout
 	TransactionSendReceiptCheckError = "Error obtaining transaction receipt (%d retries): %s"

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -358,7 +358,7 @@ const (
 	TransactionSendInputTypeNotSupported = "Type '%s' is not yet supported"
 	// TransactionSendInputCountMismatch wrong number of args supplied according to the ABI
 	TransactionSendInputCountMismatch = "Method '%s': Requires %d args (supplied=%d)"
-	// TransactionSendInputStructureWrong the JSON structure supplied to decribe the arguments is incorrect according to our schema
+	// TransactionSendInputStructureWrong the JSON structure supplied to describe the arguments is incorrect according to our schema
 	TransactionSendInputStructureWrong = "Param %d: supplied as an object must have 'type' and 'value' fields"
 	// TransactionSendInputInLineTypeArrayNotString when sending us an ABI definition for the inputs directly
 	TransactionSendInputInLineTypeArrayNotString = "Param %d: supplied as an object must be string"

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -393,6 +393,10 @@ const (
 	UnpackOutputsMismatchType = "Expected %s type in JSON/RPC response for %s (%s). Received %s"
 	// UnpackOutputsUnknownType did not know how to handle this type - enhancement required
 	UnpackOutputsUnknownType = "Unable to process type for %s (%s). Received %s"
+	// UnpackOutputsMismatchTupleType we got a type back from the unpacking that doesn't match the ABI
+	UnpackOutputsMismatchTupleType = "Unable to process type for %s (%s). Expected %s. Received %+v"
+  // UnpackOutputsMismatchTupleFieldCount we had a mismatch in the number of fields described on the ABI and the number on the go structure
+  UnpackOutputsMismatchTupleFieldCount = "Unable to process type for %s (%s). Expected %d fields on the structure. Received %d"
 
 	// Unauthorized (401 error)
 	Unauthorized = "Unauthorized"

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -354,8 +354,8 @@ const (
 	TransactionSendInputTypeBadByteOutsideRange = "Method '%s' param %s is a %s: Invalid number - outside of range for byte"
 	// TransactionSendInputTypeBadJSONTypeForBytes one of the entries inside of a byte array, is a number outside the range for bytes
 	TransactionSendInputTypeBadJSONTypeForBytes = "Method '%s' param %s is a %s: Must supply a hex string, or number array"
-  // TransactionSendInputTypeBadJSONTypeForTuple if we are provided a non object input on the JSON for a struct (tuple)
-  TransactionSendInputTypeBadJSONTypeForTuple = "Method '%s' param %s is a %s: Must supply an object (supplied=%s)"
+	// TransactionSendInputTypeBadJSONTypeForTuple if we are provided a non object input on the JSON for a struct (tuple)
+	TransactionSendInputTypeBadJSONTypeForTuple = "Method '%s' param %s is a %s: Must supply an object (supplied=%s)"
 	// TransactionSendInputTypeNotSupported did not know how to handle this type - enhancement required
 	TransactionSendInputTypeNotSupported = "Type '%s' is not yet supported"
 	// TransactionSendInputCountMismatch wrong number of args supplied according to the ABI
@@ -369,9 +369,9 @@ const (
 	// TransactionSendMsgTypeUnknown we got a JSON message into the core processor (from Kafka, Webhooks etc.) that we don't understand
 	TransactionSendMsgTypeUnknown = "Unknown message type '%s'"
 	// TransactionSendInputTooManyParams more parameters provided than specified on ABI
-  TransactionSendInputTooManyParams = "Supplied %d paramters for ABI that supports %d"
-  // TransactionSendInputNotAssignable if we end up in a situation where the generated type cannot be assiend
-  TransactionSendInputNotAssignable = "Method %s param %s: supplied value '%+v' could not be assigned to '%s' field"
+	TransactionSendInputTooManyParams = "Supplied %d paramters for ABI that supports %d"
+	// TransactionSendInputNotAssignable if we end up in a situation where the generated type cannot be assigned
+	TransactionSendInputNotAssignable = "Method %s param %s: supplied value '%+v' could not be assigned to '%s' field"
 
 	// TransactionSendReceiptCheckError we continually had bad RCs back from the node while trying to check for the receipt up to the timeout
 	TransactionSendReceiptCheckError = "Error obtaining transaction receipt (%d retries): %s"
@@ -395,8 +395,8 @@ const (
 	UnpackOutputsUnknownType = "Unable to process type for %s (%s). Received %s"
 	// UnpackOutputsMismatchTupleType we got a type back from the unpacking that doesn't match the ABI
 	UnpackOutputsMismatchTupleType = "Unable to process type for %s (%s). Expected %s. Received %+v"
-  // UnpackOutputsMismatchTupleFieldCount we had a mismatch in the number of fields described on the ABI and the number on the go structure
-  UnpackOutputsMismatchTupleFieldCount = "Unable to process type for %s (%s). Expected %d fields on the structure. Received %d"
+	// UnpackOutputsMismatchTupleFieldCount we had a mismatch in the number of fields described on the ABI and the number on the go structure
+	UnpackOutputsMismatchTupleFieldCount = "Unable to process type for %s (%s). Expected %d fields on the structure. Received %d"
 
 	// Unauthorized (401 error)
 	Unauthorized = "Unauthorized"

--- a/internal/kldeth/compiler.go
+++ b/internal/kldeth/compiler.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	// DefaultEVMVersion is the EVMVersion to be used when not specified explicity
+	// DefaultEVMVersion is the EVMVersion to be used when not specified explicitly
 	defaultEVMVersion = "byzantium"
 )
 
@@ -115,7 +115,7 @@ func CompileContract(soliditySource, contractName, requestedVersion, evmVersion 
 	if err := cmd.Run(); err != nil {
 		return nil, klderrors.Errorf(klderrors.CompilerFailedSolc, err, stderr.String())
 	}
-	c, err := compiler.ParseCombinedJSON(stdout.Bytes(), soliditySource, s.Version, s.Version, strings.Join(solcArgs, " "))
+	c, _ := compiler.ParseCombinedJSON(stdout.Bytes(), soliditySource, s.Version, s.Version, strings.Join(solcArgs, " "))
 	return ProcessCompiled(c, contractName, true)
 }
 

--- a/internal/kldeth/privacygroup_test.go
+++ b/internal/kldeth/privacygroup_test.go
@@ -34,7 +34,7 @@ func TestGetOrionPrivacyGroupExists(t *testing.T) {
 		resultWrangler: func(retString interface{}) {
 			if firstCall {
 				retVal := []OrionPrivacyGroup{
-					OrionPrivacyGroup{
+					{
 						PrivacyGroupID: "P8SxRUussJKqZu4+nUkMJpscQeWOR3HqbAXLakatsk8=",
 					},
 				}

--- a/internal/kldeth/txn.go
+++ b/internal/kldeth/txn.go
@@ -280,7 +280,7 @@ func genTupleMapOutput(argName, argType string, t *abi.Type, rawValue interface{
   reflectValue := reflect.ValueOf(rawValue)
   if reflectValue.Kind() != reflect.Struct || reflectValue.Type() != t.TupleType {
 		return nil, klderrors.Errorf(klderrors.UnpackOutputsMismatchTupleType,
-			argName, argType, rawValue, t.TupleType)
+			argName, argType, t.TupleType, rawValue)
   }
   if len(t.TupleRawNames) != reflectValue.NumField() {
 		return nil, klderrors.Errorf(klderrors.UnpackOutputsMismatchTupleFieldCount,

--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -18,16 +18,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math/big"
 	"reflect"
-  "testing"
-  "io/ioutil"
+	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/kaleido-io/ethconnect/internal/kldbind"
 	"github.com/kaleido-io/ethconnect/internal/kldmessages"
 	log "github.com/sirupsen/logrus"
-  "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 // Slim interface for stubbing
@@ -1545,142 +1545,142 @@ func TestProcessRLPBytesValidTypes(t *testing.T) {
 func TestProcessRLPV2ABIEncodedStructs(t *testing.T) {
 	assert := assert.New(t)
 
-  var v2abi abi.ABI
-  testABIInput, err := ioutil.ReadFile("../../test/abicoderv2_example.abi.json")
-  assert.NoError(err)
-  err = json.Unmarshal(testABIInput, &v2abi)
-  assert.NoError(err)
+	var v2abi abi.ABI
+	testABIInput, err := ioutil.ReadFile("../../test/abicoderv2_example.abi.json")
+	assert.NoError(err)
+	err = json.Unmarshal(testABIInput, &v2abi)
+	assert.NoError(err)
 
-  var abiMethod abi.Method
-  for _, m := range v2abi.Methods {
-    if m.Name == "inOutType1" {
-      abiMethod = m
-    }
-  }
+	var abiMethod abi.Method
+	for _, m := range v2abi.Methods {
+		if m.Name == "inOutType1" {
+			abiMethod = m
+		}
+	}
 
-  input1Map := map[string]interface{}{
-    "str1": "test1",
-    "val1": "12345",
-    "nested": map[string]interface{}{
-      "str1": "test2",
-      "str2": "test3",
-      "addr1": "0x1212121212121212121212121212121212121212",
-      "bytearray": "0xfeedbeef",
-    },
-    "nestarray": []interface{}{
-      map[string]interface{}{
-        "str1": "test4",
-        "str2": "test5",
-        "addr1": "0x2121212121212121212121212121212121212121",
-        "bytearray": "0x01010101",
-      },
-    },
-  }
+	input1Map := map[string]interface{}{
+		"str1": "test1",
+		"val1": "12345",
+		"nested": map[string]interface{}{
+			"str1":      "test2",
+			"str2":      "test3",
+			"addr1":     "0x1212121212121212121212121212121212121212",
+			"bytearray": "0xfeedbeef",
+		},
+		"nestarray": []interface{}{
+			map[string]interface{}{
+				"str1":      "test4",
+				"str2":      "test5",
+				"addr1":     "0x2121212121212121212121212121212121212121",
+				"bytearray": "0x01010101",
+			},
+		},
+	}
 
-  tx := Txn{}
-  typedArgs, err := tx.generateTypedArgs([]interface{}{input1Map}, &abiMethod)
-  assert.NoError(err)
-  t.Logf("typeArgs: %+v", typedArgs)
+	tx := Txn{}
+	typedArgs, err := tx.generateTypedArgs([]interface{}{input1Map}, &abiMethod)
+	assert.NoError(err)
+	t.Logf("typeArgs: %+v", typedArgs)
 
-  rlp, err := abiMethod.Inputs.Pack(typedArgs...)
+	rlp, err := abiMethod.Inputs.Pack(typedArgs...)
 	assert.NoError(err)
 	res, err := ProcessRLPBytes(abiMethod.Outputs, rlp)
 	assert.NoError(err)
-  assert.Nil(res["error"])
-  
-  assert.Equal(input1Map, res["out1"])
+	assert.Nil(res["error"])
+
+	assert.Equal(input1Map, res["out1"])
 }
 
 func TestProcessRLPV2ABIEncodedStructsUnasignableVal(t *testing.T) {
 	assert := assert.New(t)
 
-  var v2abi abi.ABI
-  testABIInput, err := ioutil.ReadFile("../../test/abicoderv2_example.abi.json")
-  assert.NoError(err)
-  err = json.Unmarshal(testABIInput, &v2abi)
-  assert.NoError(err)
+	var v2abi abi.ABI
+	testABIInput, err := ioutil.ReadFile("../../test/abicoderv2_example.abi.json")
+	assert.NoError(err)
+	err = json.Unmarshal(testABIInput, &v2abi)
+	assert.NoError(err)
 
-  var abiMethod abi.Method
-  for _, m := range v2abi.Methods {
-    if m.Name == "inOutType1" {
-      abiMethod = m
-    }
-  }
+	var abiMethod abi.Method
+	for _, m := range v2abi.Methods {
+		if m.Name == "inOutType1" {
+			abiMethod = m
+		}
+	}
 
-  input1Map := map[string]interface{}{
-    "str1": []interface{}{},
-  }
+	input1Map := map[string]interface{}{
+		"str1": []interface{}{},
+	}
 
-  tx := Txn{}
-  _, err = tx.generateTypedArgs([]interface{}{input1Map}, &abiMethod)
-  assert.Regexp("Method 'inOutType1' param 0.str1: Must supply a string", err.Error())
+	tx := Txn{}
+	_, err = tx.generateTypedArgs([]interface{}{input1Map}, &abiMethod)
+	assert.Regexp("Method 'inOutType1' param 0.str1: Must supply a string", err.Error())
 }
 
 func TestProcessRLPV2ABIEncodedStructsBadInputType(t *testing.T) {
 	assert := assert.New(t)
 
-  var v2abi abi.ABI
-  testABIInput, err := ioutil.ReadFile("../../test/abicoderv2_example.abi.json")
-  assert.NoError(err)
-  err = json.Unmarshal(testABIInput, &v2abi)
-  assert.NoError(err)
+	var v2abi abi.ABI
+	testABIInput, err := ioutil.ReadFile("../../test/abicoderv2_example.abi.json")
+	assert.NoError(err)
+	err = json.Unmarshal(testABIInput, &v2abi)
+	assert.NoError(err)
 
-  var abiMethod abi.Method
-  for _, m := range v2abi.Methods {
-    if m.Name == "inOutType1" {
-      abiMethod = m
-    }
-  }
+	var abiMethod abi.Method
+	for _, m := range v2abi.Methods {
+		if m.Name == "inOutType1" {
+			abiMethod = m
+		}
+	}
 
-  input1Map := map[string]interface{}{
-    "nested": "Not a map",
-  }
+	input1Map := map[string]interface{}{
+		"nested": "Not a map",
+	}
 
-  tx := Txn{}
-  _, err = tx.generateTypedArgs([]interface{}{input1Map}, &abiMethod)
-  assert.EqualError(err, "Method 'inOutType1' param 0.nested is a (string,string,address,bytes): Must supply an object (supplied=string)")
+	tx := Txn{}
+	_, err = tx.generateTypedArgs([]interface{}{input1Map}, &abiMethod)
+	assert.EqualError(err, "Method 'inOutType1' param 0.nested is a (string,string,address,bytes): Must supply an object (supplied=string)")
 }
 
 func TestGenerateTupleFromMapBadStructType(t *testing.T) {
 	assert := assert.New(t)
-  tx := Txn{}
-  type random struct { stuff string }
-  tUint, _ := abi.NewType("uint256", "", []abi.ArgumentMarshaling{})
-  _, err := tx.generateTupleFromMap("method1", "test", &abi.Type{
-    TupleType: reflect.TypeOf((*random)(nil)).Elem(), // random type that should never happen
-    TupleRawNames: []string{"field1"},
-    TupleElems: []*abi.Type{&tUint},
-  }, map[string]interface{}{"field1": float64(42)})
-  assert.EqualError(err, "Method method1 param test: supplied value '+42' could not be assigned to 'field1' field")
+	tx := Txn{}
+	type random struct{ stuff string }
+	tUint, _ := abi.NewType("uint256", "", []abi.ArgumentMarshaling{})
+	_, err := tx.generateTupleFromMap("method1", "test", &abi.Type{
+		TupleType:     reflect.TypeOf((*random)(nil)).Elem(), // random type that should never happen
+		TupleRawNames: []string{"field1"},
+		TupleElems:    []*abi.Type{&tUint},
+	}, map[string]interface{}{"field1": float64(42)})
+	assert.EqualError(err, "Method method1 param test: supplied value '+42' could not be assigned to 'field1' field")
 }
 
 func TestGenTupleMapOutputBadTypeNonStruct(t *testing.T) {
 	assert := assert.New(t)
-  type random struct { stuff string }
-  _, err := genTupleMapOutput("test", "random", &abi.Type{TupleType: reflect.TypeOf((*string)(nil)).Elem()}, 42)
-  assert.EqualError(err, "Unable to process type for test (random). Expected string. Received 42")
+	type random struct{ stuff string }
+	_, err := genTupleMapOutput("test", "random", &abi.Type{TupleType: reflect.TypeOf((*string)(nil)).Elem()}, 42)
+	assert.EqualError(err, "Unable to process type for test (random). Expected string. Received 42")
 }
 
 func TestGenTupleMapOutputBadTypeCountMismatch(t *testing.T) {
 	assert := assert.New(t)
-  type random struct { }
-  _, err := genTupleMapOutput("test", "random", &abi.Type{
-    TupleType: reflect.TypeOf((*random)(nil)).Elem(),
-    TupleRawNames: []string{"field1", "field2"},
-  }, random{})
-  assert.EqualError(err, "Unable to process type for test (random). Expected 2 fields on the structure. Received 0")
+	type random struct{}
+	_, err := genTupleMapOutput("test", "random", &abi.Type{
+		TupleType:     reflect.TypeOf((*random)(nil)).Elem(),
+		TupleRawNames: []string{"field1", "field2"},
+	}, random{})
+	assert.EqualError(err, "Unable to process type for test (random). Expected 2 fields on the structure. Received 0")
 }
 
 func TestGenTupleMapOutputBadTypeValMismatch(t *testing.T) {
 	assert := assert.New(t)
-  type random struct { Field1 string }
-  tUint, _ := abi.NewType("uint256", "", []abi.ArgumentMarshaling{})
-  _, err := genTupleMapOutput("test", "random", &abi.Type{
-    TupleType: reflect.TypeOf((*random)(nil)).Elem(),
-    TupleRawNames: []string{"field1"},
-    TupleElems: []*abi.Type{&tUint},
-  }, random{ Field1: "stuff" })
-  assert.EqualError(err, "Expected number type in JSON/RPC response for test.field1 (uint256). Received string")
+	type random struct{ Field1 string }
+	tUint, _ := abi.NewType("uint256", "", []abi.ArgumentMarshaling{})
+	_, err := genTupleMapOutput("test", "random", &abi.Type{
+		TupleType:     reflect.TypeOf((*random)(nil)).Elem(),
+		TupleRawNames: []string{"field1"},
+		TupleElems:    []*abi.Type{&tUint},
+	}, random{Field1: "stuff"})
+	assert.EqualError(err, "Expected number type in JSON/RPC response for test.field1 (uint256). Received string")
 }
 
 func TestProcessRLPBytesInvalidNumber(t *testing.T) {

--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -559,7 +559,7 @@ func TestSolidityBytesParamConversion(t *testing.T) {
 }
 
 func TestSolidityArrayOfByteArraysParamConversion(t *testing.T) {
-	// These types are wierd, as they are arrays of arrays of bytes.
+	// These types are weird, as they are arrays of arrays of bytes.
 	// We do not support HEX strings for these, but the docs explicitly discourage their
 	// use in favour of bytes8 etc.
 	testComplexParam(t, "byte[8] memory", []string{"fe", "ed", "be", "ef"}, "")
@@ -586,29 +586,29 @@ func TestSendTxnABIParam(t *testing.T) {
 	msg.Method = &kldmessages.ABIMethod{
 		Name: "testFunc",
 		Inputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "param1",
 				Type: "uint8",
 			},
-			kldmessages.ABIParam{
+			{
 				Name: "param2",
 				Type: "int256",
 			},
-			kldmessages.ABIParam{
+			{
 				Name: "param3",
 				Type: "string",
 			},
-			kldmessages.ABIParam{
+			{
 				Name: "param4",
 				Type: "address",
 			},
-			kldmessages.ABIParam{
+			{
 				Name: "param5",
 				Type: "bytes",
 			},
 		},
 		Outputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "ret1",
 				Type: "uint256",
 			},
@@ -814,7 +814,7 @@ func TestCallMethod(t *testing.T) {
 	assert.Regexp("0xe5537abb000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000007b0000000000000000000000000000000000000000000000000000000000000080000000000000000000000000aa983ad2a0e0ed8ac639277f37be42f2a5d2618c00000000000000000000000000000000000000000000000000000000000000036162630000000000000000000000000000000000000000000000000000000000", jsonSent["data"])
 	assert.Equal("latest", rpc.capturedArgs[1])
 
-	res, err = CallMethod(context.Background(), rpc, nil,
+	_, err = CallMethod(context.Background(), rpc, nil,
 		"0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c",
 		"0x2b8c0ECc76d0759a8F50b2E14A6881367D805832",
 		json.Number("12345"), genMethod(params), params, "pending")
@@ -822,7 +822,7 @@ func TestCallMethod(t *testing.T) {
 	assert.Equal("eth_call", rpc.capturedMethod2)
 	assert.Equal("pending", rpc.capturedArgs2[1])
 
-	res, err = CallMethod(context.Background(), rpc, nil,
+	_, err = CallMethod(context.Background(), rpc, nil,
 		"0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c",
 		"0x2b8c0ECc76d0759a8F50b2E14A6881367D805832",
 		json.Number("12345"), genMethod(params), params, "earliest")
@@ -830,7 +830,7 @@ func TestCallMethod(t *testing.T) {
 	assert.Equal("eth_call", rpc.capturedMethod2)
 	assert.Equal("earliest", rpc.capturedArgs2[1])
 
-	res, err = CallMethod(context.Background(), rpc, nil,
+	_, err = CallMethod(context.Background(), rpc, nil,
 		"0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c",
 		"0x2b8c0ECc76d0759a8F50b2E14A6881367D805832",
 		json.Number("12345"), genMethod(params), params, "0x1234")
@@ -838,7 +838,7 @@ func TestCallMethod(t *testing.T) {
 	assert.Equal("eth_call", rpc.capturedMethod2)
 	assert.Equal("0x1234", rpc.capturedArgs2[1])
 
-	res, err = CallMethod(context.Background(), rpc, nil,
+	_, err = CallMethod(context.Background(), rpc, nil,
 		"0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c",
 		"0x2b8c0ECc76d0759a8F50b2E14A6881367D805832",
 		json.Number("12345"), genMethod(params), params, "12345")
@@ -846,7 +846,7 @@ func TestCallMethod(t *testing.T) {
 	assert.Equal("eth_call", rpc.capturedMethod2)
 	assert.Equal("0x3039", rpc.capturedArgs2[1])
 
-	res, err = CallMethod(context.Background(), rpc, nil,
+	_, err = CallMethod(context.Background(), rpc, nil,
 		"0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c",
 		"0x2b8c0ECc76d0759a8F50b2E14A6881367D805832",
 		json.Number("12345"), genMethod(params), params, "0")
@@ -1321,13 +1321,13 @@ func TestSendTxnBadInputType(t *testing.T) {
 	msg.Method = &kldmessages.ABIMethod{
 		Name: "testFunc",
 		Inputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "param1",
 				Type: "badness",
 			},
 		},
 		Outputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "ret1",
 				Type: "uint256",
 			},
@@ -1360,13 +1360,13 @@ func TestSendTxnBadFrom(t *testing.T) {
 	msg.Method = &kldmessages.ABIMethod{
 		Name: "testFunc",
 		Inputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "param1",
 				Type: "uint8",
 			},
 		},
 		Outputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "ret1",
 				Type: "uint256",
 			},
@@ -1390,13 +1390,13 @@ func TestSendTxnBadTo(t *testing.T) {
 	msg.Method = &kldmessages.ABIMethod{
 		Name: "testFunc",
 		Inputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "param1",
 				Type: "uint8",
 			},
 		},
 		Outputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "ret1",
 				Type: "uint256",
 			},
@@ -1419,13 +1419,13 @@ func TestSendTxnBadOutputType(t *testing.T) {
 	msg.Method = &kldmessages.ABIMethod{
 		Name: "testFunc",
 		Inputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "param1",
 				Type: "uint256",
 			},
 		},
 		Outputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "ret1",
 				Type: "badness",
 			},
@@ -1443,13 +1443,13 @@ func TestSendBadParams(t *testing.T) {
 	msg.Method = &kldmessages.ABIMethod{
 		Name: "testFunc",
 		Inputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "param1",
 				Type: "int8",
 			},
 		},
 		Outputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "ret1",
 				Type: "uint256",
 			},
@@ -1467,13 +1467,13 @@ func TestSendTxnPackError(t *testing.T) {
 	msg.Method = &kldmessages.ABIMethod{
 		Name: "testFunc",
 		Inputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "param1",
 				Type: "bytes1",
 			},
 		},
 		Outputs: []kldmessages.ABIParam{
-			kldmessages.ABIParam{
+			{
 				Name: "ret1",
 				Type: "uint256",
 			},
@@ -1499,15 +1499,15 @@ func TestProcessRLPBytesValidTypes(t *testing.T) {
 		Name:   "echoTypes2",
 		Inputs: []abi.Argument{},
 		Outputs: []abi.Argument{
-			abi.Argument{Name: "retval1", Type: t1},
-			abi.Argument{Name: "retval2", Type: t2},
-			abi.Argument{Name: "retval3", Type: t3},
-			abi.Argument{Name: "retval4", Type: t4},
-			abi.Argument{Name: "retval5", Type: t5},
-			abi.Argument{Name: "retval6", Type: t6},
-			abi.Argument{Name: "retval7", Type: t7},
-			abi.Argument{Name: "retval8", Type: t8},
-			abi.Argument{Name: "retval9", Type: t9},
+			{Name: "retval1", Type: t1},
+			{Name: "retval2", Type: t2},
+			{Name: "retval3", Type: t3},
+			{Name: "retval4", Type: t4},
+			{Name: "retval5", Type: t5},
+			{Name: "retval6", Type: t6},
+			{Name: "retval7", Type: t7},
+			{Name: "retval8", Type: t8},
+			{Name: "retval9", Type: t9},
 		},
 	}
 	rlp, err := methodABI.Outputs.Pack(
@@ -1606,7 +1606,7 @@ func TestProcessRLPBytesUnpackFailure(t *testing.T) {
 		Name:   "echoTypes2",
 		Inputs: []abi.Argument{},
 		Outputs: []abi.Argument{
-			abi.Argument{Name: "retval1", Type: t1},
+			{Name: "retval1", Type: t1},
 		},
 	}
 
@@ -1622,7 +1622,7 @@ func TestProcessOutputsTooFew(t *testing.T) {
 		Name:   "echoTypes2",
 		Inputs: []abi.Argument{},
 		Outputs: []abi.Argument{
-			abi.Argument{Name: "retval1", Type: t1},
+			{Name: "retval1", Type: t1},
 		},
 	}
 
@@ -1651,8 +1651,8 @@ func TestProcessOutputsDefaultName(t *testing.T) {
 		Name:   "anonReturn",
 		Inputs: []abi.Argument{},
 		Outputs: []abi.Argument{
-			abi.Argument{Name: "", Type: t1},
-			abi.Argument{Name: "", Type: t1},
+			{Name: "", Type: t1},
+			{Name: "", Type: t1},
 		},
 	}
 
@@ -1670,7 +1670,7 @@ func TestProcessOutputsBadArgs(t *testing.T) {
 		Name:   "echoTypes2",
 		Inputs: []abi.Argument{},
 		Outputs: []abi.Argument{
-			abi.Argument{Name: "retval1", Type: t1},
+			{Name: "retval1", Type: t1},
 		},
 	}
 

--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -1560,18 +1560,19 @@ func TestProcessRLPV2ABIEncodedStructs(t *testing.T) {
 
   input1Map := map[string]interface{}{
     "str1": "test1",
-    "val1": float64(12345),
+    "val1": "12345",
     "nested": map[string]interface{}{
       "str1": "test2",
       "str2": "test3",
       "addr1": "0x1212121212121212121212121212121212121212",
-      "bytearray": "feedbeef",
-      "nestarray": []map[string]interface{}{
-        map[string]interface{}{
-          "str1": "test4",
-          "str2": "test5",
-          "address": "0x2121212121212121212121212121212121212121",
-        },
+      "bytearray": "0xfeedbeef",
+    },
+    "nestarray": []interface{}{
+      map[string]interface{}{
+        "str1": "test4",
+        "str2": "test5",
+        "addr1": "0x2121212121212121212121212121212121212121",
+        "bytearray": "0x01010101",
       },
     },
   }
@@ -1581,11 +1582,13 @@ func TestProcessRLPV2ABIEncodedStructs(t *testing.T) {
   assert.NoError(err)
   t.Logf("typeArgs: %+v", typedArgs)
 
-  _, err = abiMethod.Inputs.Pack(typedArgs...)
+  rlp, err := abiMethod.Inputs.Pack(typedArgs...)
 	assert.NoError(err)
-	// res, err := ProcessRLPBytes(abiMethod.Outputs, rlp)
-	// assert.NoError(err)
-	// assert.Nil(res["error"])
+	res, err := ProcessRLPBytes(abiMethod.Outputs, rlp)
+	assert.NoError(err)
+  assert.Nil(res["error"])
+  
+  assert.Equal(input1Map, res["out1"])
 }
 
 func TestProcessRLPBytesInvalidNumber(t *testing.T) {
@@ -1633,7 +1636,7 @@ func TestProcessRLPBytesInvalidArrayType(t *testing.T) {
 
 	t1, _ := kldbind.ABITypeFor("int32[]")
 	_, err := mapOutput("test1", "int32[]", &t1, []string{"wrong"})
-	assert.EqualError(err, "Expected number type in JSON/RPC response for test1 (int32[]). Received string")
+	assert.EqualError(err, "Expected number type in JSON/RPC response for test1[0] (int32[]). Received string")
 }
 
 func TestProcessRLPBytesInvalidTypeByte(t *testing.T) {

--- a/internal/kldevents/logprocessor_test.go
+++ b/internal/kldevents/logprocessor_test.go
@@ -67,12 +67,12 @@ func TestProcessLogEntryNillAndTooFewFields(t *testing.T) {
 			"testEvent",
 			true,
 			[]kldbind.ABIArgument{
-				kldbind.ABIArgument{
+				{
 					Name:    "one",
 					Indexed: true,
 					Type:    uint256Type,
 				},
-				kldbind.ABIArgument{
+				{
 					Name:    "two",
 					Indexed: true,
 					Type:    uint256Type,
@@ -101,11 +101,11 @@ func TestProcessLogBadRLPData(t *testing.T) {
 		event: &kldbind.ABIEvent{
 			Anonymous: true,
 			Inputs: []kldbind.ABIArgument{
-				kldbind.ABIArgument{
+				{
 					Name:    "one",
 					Indexed: false,
 				},
-				kldbind.ABIArgument{
+				{
 					Name:    "two",
 					Indexed: false,
 				},

--- a/internal/kldevents/submanager_test.go
+++ b/internal/kldevents/submanager_test.go
@@ -196,7 +196,7 @@ func TestActionChildCleanup(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	_, err = sm.AddSubscription(ctx, nil, &kldbind.ABIEvent{Name: "ping"}, stream.ID, "12345", "")
+	sm.AddSubscription(ctx, nil, &kldbind.ABIEvent{Name: "ping"}, stream.ID, "12345", "")
 	err = sm.DeleteStream(ctx, stream.ID)
 	assert.NoError(err)
 

--- a/internal/kldkafka/clientmock.go
+++ b/internal/kldkafka/clientmock.go
@@ -53,7 +53,7 @@ func (f *MockKafkaFactory) NewClient(k KafkaCommon, clientConf *sarama.Config) (
 // Brokers - mock
 func (f *MockKafkaFactory) Brokers() []*sarama.Broker {
 	return []*sarama.Broker{
-		&sarama.Broker{},
+		{},
 	}
 }
 

--- a/internal/kldkafka/kafkabridge_test.go
+++ b/internal/kldkafka/kafkabridge_test.go
@@ -223,7 +223,7 @@ func TestSingleMessageWithReply(t *testing.T) {
 	}
 	msg1.Headers.Context = msg1Ctx
 	msg1.Headers.Account = "0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c"
-	msg1bytes, err := json.Marshal(&msg1)
+	msg1bytes, _ := json.Marshal(&msg1)
 	log.Infof("Sent message: %s", string(msg1bytes))
 
 	mockConsumer.MockMessages <- &sarama.ConsumerMessage{
@@ -232,7 +232,7 @@ func TestSingleMessageWithReply(t *testing.T) {
 		Offset:    500,
 		Value:     msg1bytes,
 		Headers: []*sarama.RecordHeader{
-			&sarama.RecordHeader{
+			{
 				Key:   []byte(kldmessages.RecordHeaderAccessToken),
 				Value: []byte("testat"),
 			},
@@ -296,7 +296,7 @@ func TestSingleMessageWithNotAuthorizedReply(t *testing.T) {
 	msg1 := kldmessages.RequestCommon{}
 	msg1.Headers.MsgType = "TestSingleMessageWithErrorReply"
 	msg1.Headers.Account = "0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c"
-	msg1bytes, err := json.Marshal(&msg1)
+	msg1bytes, _ := json.Marshal(&msg1)
 	log.Infof("Sent message: %s", string(msg1bytes))
 	mockConsumer.MockMessages <- &sarama.ConsumerMessage{Value: msg1bytes}
 
@@ -333,7 +333,7 @@ func TestSingleMessageWithErrorReply(t *testing.T) {
 	msg1 := kldmessages.RequestCommon{}
 	msg1.Headers.MsgType = "TestSingleMessageWithErrorReply"
 	msg1.Headers.Account = "0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c"
-	msg1bytes, err := json.Marshal(&msg1)
+	msg1bytes, _ := json.Marshal(&msg1)
 	log.Infof("Sent message: %s", string(msg1bytes))
 	mockConsumer.MockMessages <- &sarama.ConsumerMessage{Value: msg1bytes}
 

--- a/internal/kldkafka/kafkacommon_test.go
+++ b/internal/kldkafka/kafkacommon_test.go
@@ -140,7 +140,6 @@ func TestExecuteWithIncompleteArgs(t *testing.T) {
 	testArgs = append(testArgs, []string{"--sasl-username", "testuser"}...)
 	_, err = execKafkaCommonWithArgs(assert, testArgs, f)
 	assert.Equal("Username and Password must both be provided for SASL", err.Error())
-	testArgs = append(testArgs, []string{"--sasl-password", "testpass"}...)
 
 }
 

--- a/internal/kldopenapi/abi2swagger.go
+++ b/internal/kldopenapi/abi2swagger.go
@@ -90,7 +90,7 @@ func (c *ABI2Swagger) convert(basePath, name string, abi *abi.ABI, devdocsJSON s
 			Definitions: definitions,
 			Parameters:  parameters,
 			SecurityDefinitions: map[string]*spec.SecurityScheme{
-				kaleidoAppCredential: &spec.SecurityScheme{
+				kaleidoAppCredential: {
 					SecuritySchemeProps: spec.SecuritySchemeProps{
 						Type: "basic",
 					},
@@ -155,7 +155,7 @@ func (c *ABI2Swagger) getDeclaredIDDetails(inst bool, declaredID string, inputs 
 	}
 	sig += ")"
 	search := strings.ReplaceAll(sig, "(", "\\(")
-	search = strings.ReplaceAll(sig, ")", "\\)")
+	search = strings.ReplaceAll(search, ")", "\\)")
 	methodDocs := devdocs.Get(search)
 	return constructor, sig, path, methodDocs
 }
@@ -194,7 +194,7 @@ func (c *ABI2Swagger) addRegisterPath(paths map[string]spec.PathItem) {
 			Responses: &spec.Responses{
 				ResponsesProps: spec.ResponsesProps{
 					StatusCodeResponses: map[int]spec.Response{
-						201: spec.Response{
+						201: {
 							ResponseProps: spec.ResponseProps{
 								Description: "Successfully registered",
 							},
@@ -204,12 +204,12 @@ func (c *ABI2Swagger) addRegisterPath(paths map[string]spec.PathItem) {
 			},
 			Parameters: []spec.Parameter{
 				c.getAddressParam(),
-				spec.Parameter{
+				{
 					Refable: spec.Refable{
 						Ref: registerParam,
 					},
 				},
-				spec.Parameter{
+				{
 					ParamProps: spec.ParamProps{
 						Name:     "body",
 						In:       "body",
@@ -379,7 +379,7 @@ func (c *ABI2Swagger) getCommonParameters() map[string]spec.Parameter {
 
 func (c *ABI2Swagger) addCommonParams(op *spec.Operation, isPOST bool, isConstructor bool) {
 
-	op.Security = append(op.Security, map[string][]string{kaleidoAppCredential: []string{}})
+	op.Security = append(op.Security, map[string][]string{kaleidoAppCredential: {}})
 
 	fromParam, _ := spec.NewRef("#/parameters/fromParam")
 	valueParam, _ := spec.NewRef("#/parameters/valueParam")
@@ -577,13 +577,13 @@ func (c *ABI2Swagger) buildEventPOSTPath(eventSchema string, inst bool, event ab
 			Schema: &spec.Schema{
 				SchemaProps: spec.SchemaProps{
 					Properties: map[string]spec.Schema{
-						"stream": spec.Schema{
+						"stream": {
 							SchemaProps: spec.SchemaProps{
 								Description: "The ID of an event stream already configured in the REST Gateway",
 								Type:        []string{"string"},
 							},
 						},
-						"fromBlock": spec.Schema{
+						"fromBlock": {
 							SchemaProps: spec.SchemaProps{
 								Description: "The block number to start the subscription from",
 								Type:        []string{"string"},
@@ -631,7 +631,7 @@ func (c *ABI2Swagger) buildResponses(outputSchema string, devdocs gjson.Result) 
 	return &spec.Responses{
 		ResponsesProps: spec.ResponsesProps{
 			StatusCodeResponses: map[int]spec.Response{
-				200: spec.Response{
+				200: {
 					ResponseProps: spec.ResponseProps{
 						Description: desc,
 						Schema: &spec.Schema{

--- a/internal/kldrest/webhookskafka.go
+++ b/internal/kldrest/webhookskafka.go
@@ -153,7 +153,7 @@ func (w *webhooksKafka) sendWebhookMsg(ctx context.Context, key, msgID string, m
 	accessToken := kldauth.GetAccessToken(ctx)
 	if accessToken != "" {
 		sentMsg.Headers = []sarama.RecordHeader{
-			sarama.RecordHeader{
+			{
 				Key:   []byte(kldmessages.RecordHeaderAccessToken),
 				Value: []byte(accessToken),
 			},

--- a/internal/kldtx/txndelaytracker.go
+++ b/internal/kldtx/txndelaytracker.go
@@ -66,7 +66,7 @@ type txnDelayTracker struct {
 }
 
 // GetInitialDelay - returns an initial duration, which might be the
-// current moving average, or might be artifically low to send in a
+// current moving average, or might be artificially low to send in a
 // tracer
 func (d *txnDelayTracker) GetInitialDelay() (delay time.Duration) {
 	// We start with a fraction of the average

--- a/internal/kldtx/txnprocessor.go
+++ b/internal/kldtx/txnprocessor.go
@@ -278,7 +278,7 @@ func (p *txnProcessor) addInflightWrapper(txnContext TxnContext, msg *kldmessage
 		// We've been asked to defer to the node for signing, and are not performing HD Wallet signing
 		inflight.nodeAssignNonce = true
 	} else {
-		// Alternatively we do a dirty read from the node of the highest comitted
+		// Alternatively we do a dirty read from the node of the highest committed
 		// transaction. This will be ok as long as we're the only JSON/RPC writing to
 		// this address. But if we're competing with other transactions
 		// we need to accept the possibility of 'replacement transaction underpriced'

--- a/internal/kldtx/txnprocessor_test.go
+++ b/internal/kldtx/txnprocessor_test.go
@@ -874,7 +874,7 @@ func TestOnSendTransactionMessageInflightNonce(t *testing.T) {
 		AlwaysManageNonce: true,
 	}, &kldeth.RPCConf{}).(*txnProcessor)
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"] = &inflightTxnState{}
-	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].txnsInFlight = []*inflightTxn{&inflightTxn{nonce: 100}, &inflightTxn{nonce: 101}}
+	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].txnsInFlight = []*inflightTxn{{nonce: 100}, {nonce: 101}}
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].highestNonce = 101
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = "{" +
@@ -962,7 +962,7 @@ func TestOnSendTransactionMessageOrionFailNonce(t *testing.T) {
 		OrionPrivateAPIS: true,
 	}, &kldeth.RPCConf{}).(*txnProcessor)
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"] = &inflightTxnState{}
-	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].txnsInFlight = []*inflightTxn{&inflightTxn{nonce: 100}, &inflightTxn{nonce: 101}}
+	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].txnsInFlight = []*inflightTxn{{nonce: 100}, {nonce: 101}}
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = "{" +
 		"  \"headers\":{\"type\": \"SendTransaction\"}," +
@@ -975,7 +975,7 @@ func TestOnSendTransactionMessageOrionFailNonce(t *testing.T) {
 	testRPC := &testRPC{
 		ethGetTransactionCountErr: fmt.Errorf("pop"),
 		privFindPrivacyGroupResult: []kldeth.OrionPrivacyGroup{
-			kldeth.OrionPrivacyGroup{
+			{
 				PrivacyGroupID: "P8SxRUussJKqZu4+nUkMJpscQeWOR3HqbAXLakatsk8=",
 			},
 		},
@@ -1000,7 +1000,7 @@ func TestOnSendTransactionMessageOrion(t *testing.T) {
 		OrionPrivateAPIS: true,
 	}, &kldeth.RPCConf{}).(*txnProcessor)
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"] = &inflightTxnState{}
-	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].txnsInFlight = []*inflightTxn{&inflightTxn{nonce: 100}, &inflightTxn{nonce: 101}}
+	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].txnsInFlight = []*inflightTxn{{nonce: 100}, {nonce: 101}}
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = "{" +
 		"  \"headers\":{\"type\": \"SendTransaction\"}," +
@@ -1013,7 +1013,7 @@ func TestOnSendTransactionMessageOrion(t *testing.T) {
 	testRPC := &testRPC{
 		ethSendTransactionResult: "0xac18e98664e160305cdb77e75e5eae32e55447e94ad8ceb0123729589ed09f8b",
 		privFindPrivacyGroupResult: []kldeth.OrionPrivacyGroup{
-			kldeth.OrionPrivacyGroup{
+			{
 				PrivacyGroupID: "P8SxRUussJKqZu4+nUkMJpscQeWOR3HqbAXLakatsk8=",
 			},
 		},
@@ -1037,7 +1037,7 @@ func TestOnSendTransactionMessageOrionPrivacyGroupId(t *testing.T) {
 		OrionPrivateAPIS: true,
 	}, &kldeth.RPCConf{}).(*txnProcessor)
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"] = &inflightTxnState{}
-	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].txnsInFlight = []*inflightTxn{&inflightTxn{nonce: 100}, &inflightTxn{nonce: 101}}
+	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].txnsInFlight = []*inflightTxn{{nonce: 100}, {nonce: 101}}
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = "{" +
 		"  \"headers\":{\"type\": \"SendTransaction\"}," +
@@ -1100,7 +1100,7 @@ func TestOnSendTransactionAddressBook(t *testing.T) {
 	}).(*txnProcessor)
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"] = &inflightTxnState{}
 	txnProcessor.inflightTxns["0x83dbc8e329b38cba0fc4ed99b1ce9c2a390abdc1"].txnsInFlight =
-		[]*inflightTxn{&inflightTxn{nonce: 100}, &inflightTxn{nonce: 101}}
+		[]*inflightTxn{{nonce: 100}, {nonce: 101}}
 	testTxnContext := &testTxnContext{}
 	testTxnContext.jsonMsg = "{" +
 		"  \"headers\":{\"type\": \"SendTransaction\"}," +

--- a/internal/kldutils/httprequester.go
+++ b/internal/kldutils/httprequester.go
@@ -80,8 +80,8 @@ func (hr *HTTPRequester) DoRequest(method, url string, bodyMap map[string]interf
 	if res.StatusCode == 204 {
 		jsonBody = make(map[string]interface{})
 	} else {
-		resBody, ehr := ioutil.ReadAll(res.Body)
-		if ehr = json.Unmarshal(resBody, &jsonBody); ehr != nil {
+		resBody, _ := ioutil.ReadAll(res.Body)
+		if err := json.Unmarshal(resBody, &jsonBody); err != nil {
 			log.Errorf("%s %s <-- [%d] !Failed to read body: %s", method, url, res.StatusCode, ehr)
 			return nil, klderrors.Errorf(klderrors.HTTPRequesterStatusErrorNoData, hr.name, res.StatusCode)
 		}

--- a/internal/kldutils/httprequester_test.go
+++ b/internal/kldutils/httprequester_test.go
@@ -95,7 +95,7 @@ func TestHTTPRequesterPOSTSuccess(t *testing.T) {
 
 	hr := NewHTTPRequester("unit test", &HTTPRequesterConf{
 		Headers: map[string][]string{
-			"someheader": []string{"headerval"},
+			"someheader": {"headerval"},
 		},
 	})
 

--- a/test/abicoderv2_example.abi.json
+++ b/test/abicoderv2_example.abi.json
@@ -1,0 +1,153 @@
+[
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "str1",
+            "type": "string"
+          },
+          {
+            "internalType": "uint232",
+            "name": "val1",
+            "type": "uint232"
+          },
+          {
+            "components": [
+              {
+                "internalType": "string",
+                "name": "str1",
+                "type": "string"
+              },
+              {
+                "internalType": "string",
+                "name": "str2",
+                "type": "string"
+              },
+              {
+                "internalType": "address",
+                "name": "addr1",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "bytearray",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct ExampleV2Coder.Type2",
+            "name": "nested",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "string",
+                "name": "str1",
+                "type": "string"
+              },
+              {
+                "internalType": "string",
+                "name": "str2",
+                "type": "string"
+              },
+              {
+                "internalType": "address",
+                "name": "addr1",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "bytearray",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct ExampleV2Coder.Type2[]",
+            "name": "nestarray",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct ExampleV2Coder.Type1",
+        "name": "arg1",
+        "type": "tuple"
+      }
+    ],
+    "name": "inOutType1",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "str1",
+            "type": "string"
+          },
+          {
+            "internalType": "uint232",
+            "name": "val1",
+            "type": "uint232"
+          },
+          {
+            "components": [
+              {
+                "internalType": "string",
+                "name": "str1",
+                "type": "string"
+              },
+              {
+                "internalType": "string",
+                "name": "str2",
+                "type": "string"
+              },
+              {
+                "internalType": "address",
+                "name": "addr1",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "bytearray",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct ExampleV2Coder.Type2",
+            "name": "nested",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "string",
+                "name": "str1",
+                "type": "string"
+              },
+              {
+                "internalType": "string",
+                "name": "str2",
+                "type": "string"
+              },
+              {
+                "internalType": "address",
+                "name": "addr1",
+                "type": "address"
+              },
+              {
+                "internalType": "bytes",
+                "name": "bytearray",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct ExampleV2Coder.Type2[]",
+            "name": "nestarray",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct ExampleV2Coder.Type1",
+        "name": "out1",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  }
+]

--- a/test/abicoderv2_example.sol
+++ b/test/abicoderv2_example.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.6.3;
+pragma experimental ABIEncoderV2;
+
+contract ExampleV2Coder {
+
+    struct Type1 {
+        string str1;
+        uint232 val1;
+        Type2 nested;
+        Type2[] nestarray;
+    }
+
+    struct Type2 {
+      string str1;
+      string str2;
+      address addr1;
+      bytes bytearray;
+    }
+
+    function inOutType1(Type1 memory arg1) public pure returns(Type1 memory out1) {
+        return arg1;
+    }
+}


### PR DESCRIPTION
Updates the core JSON <-> ABI logic of ethconnect to handle `ABIEncoderV2` encoded structs.

- Updates error messages to include the path to the field that is in error, including array indexes and nesting
- Tested with nested structures and arrays
- Validated fields are optional on structures
- Exploits all the same type mapping of the individual fields to/from JSON that top-level fields have
- Also includes some format and spelling fixes identified by go report.

Additional work likely to be required around OpenAPI (Swagger) generation, and potentially events.
