### PR TITLE
More work on ABIEncoderV2 to account for missing Marshal implementations

### DIFF
--- a/internal/kldbind/types.go
+++ b/internal/kldbind/types.go
@@ -55,7 +55,13 @@ type ABIMethod = abi.Method
 type ABIEvent = abi.Event
 
 // ABIArgumentMarshaling is abi.ArgumentMarshaling
-type ABIArgumentMarshaling = abi.ArgumentMarshaling
+type ABIArgumentMarshaling struct {
+	Name         string                  `json:"name"`
+	Type         string                  `json:"type"`
+	InternalType string                  `json:"internalType,omitempty"`
+	Components   []ABIArgumentMarshaling `json:"components,omitempty"`
+	Indexed      bool                    `json:"indexed,omitempty"`
+}
 
 // ABIElementMarshaling is the serialized representation of a method or event in an ABI
 type ABIElementMarshaling struct {

--- a/internal/kldbind/types.go
+++ b/internal/kldbind/types.go
@@ -21,7 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// This module provides some basic types proxied through from ethereum, to avoid
+// This module provides some basic types proxied through from ethereØum, to avoid
 // ethereum imports throughout the codebase
 
 // Address models and serializes a 20 byte ethereum address
@@ -39,9 +39,6 @@ type HexUint64 = hexutil.Uint64
 // HexUint models and serializes uint
 type HexUint = hexutil.Uint
 
-// ABIEvent is an event on the ABI
-type ABIEvent = abi.Event
-
 // ABIArguments is an array of arguments with helper functions
 type ABIArguments = abi.Arguments
 
@@ -54,24 +51,31 @@ type ABIType = abi.Type
 // ABIMethod is an method on the ABI
 type ABIMethod = abi.Method
 
+// ABIEvent is an event on the ABI
+type ABIEvent = abi.Event
+
 // ABIArgumentMarshaling is abi.ArgumentMarshaling
 type ABIArgumentMarshaling = abi.ArgumentMarshaling
 
-// ABI is a wrapper around the ethereum ABI implementation that includes
-// marshal, as well as unmarshal
-type ABI struct {
+// ABIElementMarshaling is the serialized representation of a method or event in an ABI
+type ABIElementMarshaling struct {
+	Type            string                  `json:"type,omitempty"`
+	Name            string                  `json:"name,omitempty"`
+	Payable         bool                    `json:"payable,omitempty"`
+	Constant        bool                    `json:"constant,omitempty"`
+	Anonymous       bool                    `json:"anonymous,omitempty"`
+	StateMutability string                  `json:"stateMutability,omitempty"`
+	Inputs          []ABIArgumentMarshaling `json:"inputs"`
+	Outputs         []ABIArgumentMarshaling `json:"outputs"`
+}
+
+// ABIMarshaling is the JSON array representation of an ABI
+type ABIMarshaling []ABIElementMarshaling
+
+// RuntimeABI is the ethereum implementation of an ABI. It can be unmarshalled from an ABI JSON,
+// but does not support marshalling.
+type RuntimeABI struct {
 	abi.ABI
-}
-
-// NewABIEvent constructor for abi.Event
-func NewABIEvent(name, rawName string, anonymous bool, inputs ABIArguments) *ABIEvent {
-	abiEvent := abi.NewEvent(name, rawName, anonymous, inputs)
-	return &abiEvent
-}
-
-// NewABIType constructor for abi.Type
-func NewABIType(t string, internalType string, components []ABIArgumentMarshaling) (ABIType, error) {
-	return abi.NewType(t, internalType, components)
 }
 
 // Header is a type for ethereum block Header representation

--- a/internal/kldbind/types.go
+++ b/internal/kldbind/types.go
@@ -21,7 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// This module provides some basic types proxied through from ethereØum, to avoid
+// This module provides some basic types proxied through from ethereum, to avoid
 // ethereum imports throughout the codebase
 
 // Address models and serializes a 20 byte ethereum address

--- a/internal/kldbind/typeutils.go
+++ b/internal/kldbind/typeutils.go
@@ -127,5 +127,4 @@ func ABIElementMarshalingToABIMethod(m *ABIElementMarshaling) (method *ABIMethod
 			method = &nMethod
 		}
 	}
-	return
 }

--- a/internal/kldbind/typeutils.go
+++ b/internal/kldbind/typeutils.go
@@ -90,7 +90,12 @@ func ABIArgumentsMarshalingToABIArguments(marshalable []ABIArgumentMarshaling) (
 	arguments := make(ABIArguments, len(marshalable))
 	var err error
 	for i, mArg := range marshalable {
-		arguments[i].Type, err = abi.NewType(mArg.Type, mArg.InternalType, mArg.Components)
+		var components []abi.ArgumentMarshaling
+		if mArg.Components != nil {
+			b, _ := json.Marshal(&mArg.Components)
+			json.Unmarshal(b, &components)
+		}
+		arguments[i].Type, err = abi.NewType(mArg.Type, mArg.InternalType, components)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/kldbind/typeutils.go
+++ b/internal/kldbind/typeutils.go
@@ -74,108 +74,53 @@ func ABIEventSignature(event *ABIEvent) string {
 	return fmt.Sprintf("%v(%v)", event.RawName, strings.Join(typeStrings, ","))
 }
 
-type arg struct {
-	Name    string `json:"name,omitempty"`
-	Type    string `json:"type,omitempty"`
-	Indexed bool   `json:"indexed"`
+// ABIMarshalingToABIRuntime takes a serialized form ABI and converts it into RuntimeABI
+// This is not performance optimized, so the RuntimeABI once generated should be used
+// for runtime processing
+func ABIMarshalingToABIRuntime(marshalable ABIMarshaling) (*RuntimeABI, error) {
+	var runtime RuntimeABI
+	b, _ := json.Marshal(&marshalable)
+	err := json.Unmarshal(b, &runtime)
+	return &runtime, err
 }
 
-type field struct {
-	Type            string `json:"type,omitempty"`
-	Name            string `json:"name,omitempty"`
-	Constant        bool   `json:"constant,omitempty"`
-	Anonymous       bool   `json:"anonymous,omitempty"`
-	StateMutability string `json:"stateMutability,omitempty"`
-	Inputs          []arg
-	Outputs         []arg
-}
-
-// MarshalJSON implements the reverse of UnmarshalJSON
-func (abi *ABI) MarshalJSON() ([]byte, error) {
-	var fields []field
-	fields = append(fields, field{
-		Type:            "constructor",
-		StateMutability: abi.Constructor.StateMutability,
-		Inputs:          marshalArgs(abi.Constructor.Inputs),
-	})
-	for name, method := range abi.Methods {
-		fields = append(fields, field{
-			Type:            "function",
-			Name:            name,
-			Constant:        method.IsConstant(),
-			StateMutability: method.StateMutability,
-			Inputs:          marshalArgs(method.Inputs),
-			Outputs:         marshalArgs(method.Outputs),
-		})
-	}
-	for name, event := range abi.Events {
-		fields = append(fields, field{
-			Type:      "event",
-			Name:      name,
-			Anonymous: event.Anonymous,
-			Inputs:    marshalArgs(event.Inputs),
-		})
-	}
-	return json.Marshal(&fields)
-}
-
-// MarshalledABIEvent needed because events can't be marshalled correctly either with abi.Event
-type MarshalledABIEvent struct {
-	E ABIEvent
-}
-
-// UnmarshalJSON converts to the inner structure
-func (e *MarshalledABIEvent) UnmarshalJSON(data []byte) error {
-	var field field
-	if err := json.Unmarshal(data, &field); err != nil {
-		return err
-	}
-	inputs, err := unmarshalArgs(field.Inputs)
-	if err != nil {
-		return err
-	}
-	e.E = ABIEvent{
-		Name:      field.Name,
-		Anonymous: field.Anonymous,
-		Inputs:    inputs,
-	}
-	return nil
-}
-
-// MarshalJSON converts from the inner structure
-func (e *MarshalledABIEvent) MarshalJSON() ([]byte, error) {
-	field := field{
-		Name:      e.E.Name,
-		Anonymous: e.E.Anonymous,
-		Inputs:    marshalArgs(e.E.Inputs),
-	}
-	return json.Marshal(&field)
-}
-
-func marshalArgs(abiArgs []ABIArgument) []arg {
-	args := make([]arg, 0, len(abiArgs))
-	for _, abiArg := range abiArgs {
-		args = append(args, arg{
-			Name:    abiArg.Name,
-			Type:    abiArg.Type.String(),
-			Indexed: abiArg.Indexed,
-		})
-	}
-	return args
-}
-
-func unmarshalArgs(args []arg) ([]ABIArgument, error) {
-	abiArgs := make([]ABIArgument, 0, len(args))
-	for _, arg := range args {
-		t, err := ABITypeFor(arg.Type)
+// ABIArgumentsMarshalingToABIArguments converts ABI serialized reprsentations of arguments
+// to the processed type information
+func ABIArgumentsMarshalingToABIArguments(marshalable []ABIArgumentMarshaling) (ABIArguments, error) {
+	arguments := make(ABIArguments, len(marshalable))
+	var err error
+	for i, mArg := range marshalable {
+		arguments[i].Type, err = abi.NewType(mArg.Type, mArg.InternalType, mArg.Components)
 		if err != nil {
 			return nil, err
 		}
-		abiArgs = append(abiArgs, ABIArgument{
-			Name:    arg.Name,
-			Type:    t,
-			Indexed: arg.Indexed,
-		})
+		arguments[i].Name = mArg.Name
+		arguments[i].Indexed = mArg.Indexed
 	}
-	return abiArgs, nil
+	return arguments, nil
+}
+
+// ABIElementMarshalingToABIEvent converts a de-serialized event with full type information,
+// per the original ABI, into a runtime ABIEvent with a processed type
+func ABIElementMarshalingToABIEvent(marshalable *ABIElementMarshaling) (event *ABIEvent, err error) {
+	inputs, err := ABIArgumentsMarshalingToABIArguments(marshalable.Inputs)
+	if err == nil {
+		nEvent := abi.NewEvent(marshalable.Name, marshalable.Name, marshalable.Anonymous, inputs)
+		event = &nEvent
+	}
+	return
+}
+
+// ABIElementMarshalingToABIMethod converts a de-serialized method with full type information,
+// per the original ABI, into a runtime ABIEvent with a processed type
+func ABIElementMarshalingToABIMethod(m *ABIElementMarshaling) (method *ABIMethod, err error) {
+	inputs, err := ABIArgumentsMarshalingToABIArguments(m.Inputs)
+	if err == nil {
+		outputs, err := ABIArgumentsMarshalingToABIArguments(m.Outputs)
+		if err == nil {
+			nMethod := abi.NewMethod(m.Name, m.Name, abi.Function, m.StateMutability, m.Constant, m.Payable, inputs, outputs)
+			method = &nMethod
+		}
+	}
+	return
 }

--- a/internal/kldbind/typeutils.go
+++ b/internal/kldbind/typeutils.go
@@ -127,4 +127,5 @@ func ABIElementMarshalingToABIMethod(m *ABIElementMarshaling) (method *ABIMethod
 			method = &nMethod
 		}
 	}
+	return
 }

--- a/internal/kldbind/typeutils_test.go
+++ b/internal/kldbind/typeutils_test.go
@@ -54,12 +54,9 @@ func TestABITypeKnown(t *testing.T) {
 func TestABISignature(t *testing.T) {
 	assert := assert.New(t)
 
-	tuint256, _ := abi.NewType("uint256", "uint256", []ABIArgumentMarshaling{})
-	assert.Equal("uint256", tuint256.String())
-
 	ev := abi.NewEvent("test", "test", true, ABIArguments{ABIArgument{
 		Name: "arg1",
-		Type: tuint256,
+		Type: ABITypeKnown("uint256"),
 	}})
 	assert.Equal("test(uint256)", ABIEventSignature(&ev))
 

--- a/internal/kldbind/typeutils_test.go
+++ b/internal/kldbind/typeutils_test.go
@@ -16,9 +16,11 @@ package kldbind
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,108 +46,121 @@ func TestABITypeFor(t *testing.T) {
 	assert.Equal("uint256", abiType.String())
 }
 
-func TestABIMarshalUnMarshal(t *testing.T) {
+func TestABITypeKnown(t *testing.T) {
 	assert := assert.New(t)
-
-	tUint256, _ := abi.NewType("uint256", "", []abi.ArgumentMarshaling{})
-	a1 := ABI{
-		ABI: abi.ABI{
-			Constructor: abi.NewMethod(
-				"",
-				"",
-				abi.Constructor,
-				"",
-				false,
-				false,
-				abi.Arguments{
-					abi.Argument{Name: "carg1", Type: tUint256, Indexed: true},
-				},
-				nil,
-			),
-			Methods: map[string]abi.Method{
-				"method1": abi.NewMethod(
-					"method1",
-					"method1",
-					abi.Function,
-					"",
-					true,
-					false,
-					abi.Arguments{
-						abi.Argument{Name: "marg1", Type: tUint256, Indexed: true},
-					},
-					abi.Arguments{
-						abi.Argument{Name: "ret1", Type: tUint256, Indexed: true},
-					},
-				),
-			},
-			Events: map[string]abi.Event{
-				"event1": abi.NewEvent(
-					"event1",
-					"event1",
-					true,
-					abi.Arguments{
-						abi.Argument{Name: "earg1", Type: tUint256, Indexed: true},
-					},
-				),
-			},
-		},
-	}
-
-	jsonBytes, err := json.Marshal(&a1)
-	assert.NoError(err)
-
-	var a2 ABI
-	err = json.Unmarshal(jsonBytes, &a2)
-	assert.NoError(err)
-
-	t.Log(string(jsonBytes))
-
-	assert.Equal(a1, a2)
-}
-
-func TestABIEventMarshalUnMarshal(t *testing.T) {
-	assert := assert.New(t)
-
-	me := MarshalledABIEvent{
-		E: ABIEvent{
-			Name:      "event1",
-			Anonymous: true,
-			Inputs: abi.Arguments{
-				abi.Argument{Name: "earg1", Type: ABITypeKnown("uint256"), Indexed: true},
-			},
-		},
-	}
-
-	jsonBytes, err := json.Marshal(&me)
-	assert.NoError(err)
-
-	var me2 MarshalledABIEvent
-	err = json.Unmarshal(jsonBytes, &me2)
-	assert.NoError(err)
-
-	t.Log(string(jsonBytes))
-
-	assert.Equal(me, me2)
-
-	badType := "{\"inputs\": [{\"type\":\"badness\"}]}"
-	err = json.Unmarshal([]byte(badType), &me)
-	assert.EqualError(err, "unsupported arg type: badness")
-
-	badStuct := "{\"inputs\": false}"
-	err = json.Unmarshal([]byte(badStuct), &me)
-	assert.Regexp("cannot unmarshal", err.Error())
+	assert.Equal("uint256", ABITypeKnown("uint256").String())
 }
 
 func TestABISignature(t *testing.T) {
 	assert := assert.New(t)
 
-	tuint256, _ := NewABIType("uint256", "uint256", []ABIArgumentMarshaling{})
+	tuint256, _ := abi.NewType("uint256", "uint256", []ABIArgumentMarshaling{})
 	assert.Equal("uint256", tuint256.String())
 
-	ev := NewABIEvent("test", "test", true, ABIArguments{ABIArgument{
+	ev := abi.NewEvent("test", "test", true, ABIArguments{ABIArgument{
 		Name: "arg1",
 		Type: tuint256,
 	}})
-	assert.Equal("test(uint256)", ABIEventSignature(ev))
+	assert.Equal("test(uint256)", ABIEventSignature(&ev))
+
+}
+
+func TestRABIMarshalingToABIRuntime(t *testing.T) {
+	assert := assert.New(t)
+
+	var marshalableABI ABIMarshaling
+	b, err := ioutil.ReadFile("../../test/abicoderv2_example.abi.json")
+	assert.NoError(err)
+	err = json.Unmarshal(b, &marshalableABI)
+	assert.NoError(err)
+
+	runtimeABI, err := ABIMarshalingToABIRuntime(marshalableABI)
+	assert.NoError(err)
+	assert.Equal(abi.TupleTy, runtimeABI.Methods["inOutType1"].Inputs[0].Type.T)
+}
+
+func TestABIElementMarshalingToABIEvent(t *testing.T) {
+	assert := assert.New(t)
+
+	eventBytes := `{
+    "components": [
+      {
+        "internalType": "string",
+        "name": "str1",
+        "type": "string"
+      },
+      {
+        "internalType": "uint232",
+        "name": "val1",
+        "type": "uint232"
+      }
+    ],
+    "internalType": "struct ExampleV2Coder.Type1",
+    "name": "input1",
+    "type": "tuple"
+  }`
+
+	var input1 ABIArgumentMarshaling
+	json.Unmarshal([]byte(eventBytes), &input1)
+	marshalable := &ABIElementMarshaling{
+		Name:   "testevent",
+		Inputs: []ABIArgumentMarshaling{input1},
+	}
+
+	event, err := ABIElementMarshalingToABIEvent(marshalable)
+	assert.NoError(err)
+	assert.Equal(abi.TupleTy, event.Inputs[0].Type.T)
+
+}
+
+func TestABIElementMarshalingToABIMethod(t *testing.T) {
+	assert := assert.New(t)
+
+	eventBytes := `{
+    "components": [
+      {
+        "internalType": "string",
+        "name": "str1",
+        "type": "string"
+      },
+      {
+        "internalType": "uint232",
+        "name": "val1",
+        "type": "uint232"
+      }
+    ],
+    "internalType": "struct ExampleV2Coder.Type1",
+    "name": "input1",
+    "type": "tuple"
+  }`
+
+	var input1 ABIArgumentMarshaling
+	json.Unmarshal([]byte(eventBytes), &input1)
+	marshalable := &ABIElementMarshaling{
+		Name:     "testmethod",
+		Constant: true,
+		Inputs:   []ABIArgumentMarshaling{input1},
+		Outputs:  []ABIArgumentMarshaling{input1},
+	}
+
+	method, err := ABIElementMarshalingToABIMethod(marshalable)
+	assert.NoError(err)
+	assert.Equal(abi.TupleTy, method.Inputs[0].Type.T)
+	assert.Equal(abi.TupleTy, method.Outputs[0].Type.T)
+	assert.Equal(true, method.IsConstant())
+
+}
+
+func TestABIElementMarshalingToABIMethodFail(t *testing.T) {
+	assert := assert.New(t)
+
+	marshalable := &ABIElementMarshaling{
+		Name:     "testmethod",
+		Constant: true,
+		Inputs:   []ABIArgumentMarshaling{{Name: "test", Type: "badness"}},
+	}
+
+	_, err := ABIElementMarshalingToABIMethod(marshalable)
+	assert.EqualError(err, "unsupported arg type: badness")
 
 }

--- a/internal/kldcontracts/remoteregistry.go
+++ b/internal/kldcontracts/remoteregistry.go
@@ -144,7 +144,7 @@ func (rr *remoteRegistry) loadFactoryFromURL(baseURL, ns, lookupStr string) (*de
 	if err != nil {
 		return nil, err
 	}
-	var abi *kldbind.ABI
+	var abi kldbind.ABIMarshaling
 	err = json.Unmarshal([]byte(abiString), &abi)
 	if err != nil {
 		log.Errorf("GET %s <-- !Failed to decode ABI: %s\n%s", queryURL, err, abiString)

--- a/internal/kldcontracts/remoteregsitry_test.go
+++ b/internal/kldcontracts/remoteregsitry_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/kaleido-io/ethconnect/internal/kldbind"
 	"github.com/kaleido-io/ethconnect/internal/kldkvstore"
 	"github.com/kaleido-io/ethconnect/internal/kldmessages"
 	"github.com/stretchr/testify/assert"
@@ -161,7 +162,9 @@ func TestRemoteRegistryloadFactoryForGatewaySuccess(t *testing.T) {
 	res, err := rr.loadFactoryForGateway("testid")
 	assert.NoError(err)
 	assert.NotEmpty(res.Compiled)
-	assert.Equal("set", res.ABI.Methods["set"].Name)
+	runtimeABI, err := kldbind.ABIMarshalingToABIRuntime(res.ABI)
+	assert.NoError(err)
+	assert.Equal("set", runtimeABI.Methods["set"].Name)
 	assert.Contains(res.DevDoc, "set")
 }
 

--- a/internal/kldcontracts/rest2eth.go
+++ b/internal/kldcontracts/rest2eth.go
@@ -181,24 +181,22 @@ func (r *rest2eth) addRoutes(router *httprouter.Router) {
 }
 
 type restCmd struct {
-	from        string
-	addr        string
-	value       json.Number
-	abiMethod   *abi.Method
-	abiEvent    *abi.Event
-	isDeploy    bool
-	deployMsg   *kldmessages.DeployContract
-	body        map[string]interface{}
-	msgParams   []interface{}
-	blocknumber string
+	from         string
+	addr         string
+	value        json.Number
+	abiMethod    *kldbind.ABIMethod
+	abiEvent     *kldbind.ABIEvent
+	abiEventElem *kldbind.ABIElementMarshaling
+	isDeploy     bool
+	deployMsg    *kldmessages.DeployContract
+	body         map[string]interface{}
+	msgParams    []interface{}
+	blocknumber  string
 }
 
-func (r *rest2eth) resolveParams(res http.ResponseWriter, req *http.Request, params httprouter.Params) (c restCmd, err error) {
-
-	// Check if we have a valid address in :address (verified later if required)
-	addrParam := params.ByName("address")
+func (r *rest2eth) resolveABI(res http.ResponseWriter, req *http.Request, params httprouter.Params, c *restCmd, addrParam string) (a kldbind.ABIMarshaling, validAddress bool, err error) {
 	c.addr = strings.ToLower(strings.TrimPrefix(addrParam, "0x"))
-	validAddress := addrCheck.MatchString(c.addr)
+	validAddress = addrCheck.MatchString(c.addr)
 
 	// There are multiple ways we resolve the path into an ABI
 	// 1. we lookup it up remotely in a REST attached contract registry (the newer option)
@@ -207,7 +205,6 @@ func (r *rest2eth) resolveParams(res http.ResponseWriter, req *http.Request, par
 	// 2. we lookup it up locally in a simple filestore managed in ethconnect (the original option)
 	//    - /abis      is for factory interfaces installed into ethconnect by uploading the Solidity
 	//    - /contracts is for individual instances deployed via ethconnect factory interfaces
-	var a *kldbind.ABI
 	if strings.HasPrefix(req.URL.Path, "/gateways/") || strings.HasPrefix(req.URL.Path, "/g/") {
 		c.deployMsg, err = r.rr.loadFactoryForGateway(params.ByName("gateway_lookup"))
 		if err != nil {
@@ -241,7 +238,6 @@ func (r *rest2eth) resolveParams(res http.ResponseWriter, req *http.Request, par
 				r.restErrReply(res, req, err, 404)
 				return
 			}
-			a = c.deployMsg.ABI
 		} else {
 			if !validAddress {
 				// Resolve the address as a registered name, to an actual contract address
@@ -255,11 +251,76 @@ func (r *rest2eth) resolveParams(res http.ResponseWriter, req *http.Request, par
 			c.deployMsg, _, err = r.gw.loadDeployMsgForInstance(addrParam)
 			if err != nil {
 				r.restErrReply(res, req, err, 404)
-				return c, err
+				return
 			}
 		}
 	}
 	a = c.deployMsg.ABI
+	return
+}
+
+func (r *rest2eth) resolveMethod(res http.ResponseWriter, req *http.Request, c *restCmd, a kldbind.ABIMarshaling, methodParam string) (err error) {
+	for _, element := range a {
+		if element.Type == "function" && element.Name == methodParam {
+			if c.abiMethod, err = kldbind.ABIElementMarshalingToABIMethod(&element); err != nil {
+				err = klderrors.Errorf(klderrors.RESTGatewayMethodABIInvalid, methodParam, err)
+				r.restErrReply(res, req, err, 400)
+				return
+			}
+			return
+		}
+	}
+	return
+}
+
+func (r *rest2eth) resolveConstructor(res http.ResponseWriter, req *http.Request, c *restCmd, a kldbind.ABIMarshaling) (err error) {
+	for _, element := range a {
+		if element.Type == "constructor" {
+			if c.abiMethod, err = kldbind.ABIElementMarshalingToABIMethod(&element); err != nil {
+				err = klderrors.Errorf(klderrors.RESTGatewayMethodABIInvalid, "constructor", err)
+				r.restErrReply(res, req, err, 400)
+				return
+			}
+			c.isDeploy = true
+			return
+		}
+	}
+	return
+}
+
+func (r *rest2eth) resolveEvent(res http.ResponseWriter, req *http.Request, c *restCmd, a kldbind.ABIMarshaling, methodParam, methodParamLC, addrParam string) (err error) {
+	var eventDef *kldbind.ABIElementMarshaling
+	for _, element := range a {
+		if element.Type == "event" {
+			if element.Name == methodParam {
+				eventDef = &element
+				break
+			}
+			if methodParamLC == "subscribe" && element.Name == addrParam {
+				c.addr = ""
+				eventDef = &element
+				break
+			}
+		}
+	}
+	if eventDef != nil {
+		c.abiEventElem = eventDef
+		if c.abiEvent, err = kldbind.ABIElementMarshalingToABIEvent(eventDef); err != nil {
+			err = klderrors.Errorf(klderrors.RESTGatewayEventABIInvalid, eventDef.Name, err)
+			r.restErrReply(res, req, err, 400)
+			return
+		}
+	}
+	return
+}
+
+func (r *rest2eth) resolveParams(res http.ResponseWriter, req *http.Request, params httprouter.Params) (c restCmd, err error) {
+	// Check if we have a valid address in :address (verified later if required)
+	addrParam := params.ByName("address")
+	a, validAddress, err := r.resolveABI(res, req, params, &c, addrParam)
+	if err != nil {
+		return c, err
+	}
 
 	// See addRoutes for all the various routes we support under the factory/instance.
 	// We need to handle the special case of
@@ -271,11 +332,8 @@ func (r *rest2eth) resolveParams(res http.ResponseWriter, req *http.Request, par
 	methodParam := params.ByName("method")
 	methodParamLC := strings.ToLower(methodParam)
 	if methodParam != "" {
-		for _, method := range a.ABI.Methods {
-			if method.Name == methodParam {
-				c.abiMethod = &method
-				break
-			}
+		if err = r.resolveMethod(res, req, &c, a, methodParam); err != nil {
+			return
 		}
 	}
 
@@ -283,23 +341,16 @@ func (r *rest2eth) resolveParams(res http.ResponseWriter, req *http.Request, par
 	// an event in either the :event OR :address param (see special case above)
 	// Note solidity guarantees no overlap in method / event names
 	if c.abiMethod == nil && methodParam != "" {
-		for _, event := range a.ABI.Events {
-			if event.Name == methodParam {
-				c.abiEvent = &event
-				break
-			}
-			if methodParamLC == "subscribe" && event.Name == addrParam {
-				c.addr = ""
-				c.abiEvent = &event
-				break
-			}
+		if err = r.resolveEvent(res, req, &c, a, methodParam, methodParamLC, addrParam); err != nil {
+			return
 		}
 	}
 
 	// Last case is the constructor, where nothing is specified
 	if methodParam == "" && c.abiMethod == nil && c.abiEvent == nil {
-		c.abiMethod = &a.ABI.Constructor
-		c.isDeploy = true
+		if err = r.resolveConstructor(res, req, &c, a); err != nil {
+			return
+		}
 	}
 
 	// If we didn't find the method or event, report to the user
@@ -384,7 +435,7 @@ func (r *rest2eth) restHandler(res http.ResponseWriter, req *http.Request, param
 	}
 
 	if c.abiEvent != nil {
-		r.subscribeEvent(res, req, c.addr, c.abiEvent, c.body)
+		r.subscribeEvent(res, req, c.addr, c.abiEventElem, c.body)
 	} else if (req.Method == http.MethodPost && !c.abiMethod.IsConstant()) && strings.ToLower(getKLDParam("call", req, true)) != "true" {
 		if c.from == "" {
 			err = klderrors.Errorf(klderrors.RESTGatewayMissingFromAddress)
@@ -408,7 +459,7 @@ func (r *rest2eth) fromBodyOrForm(req *http.Request, body map[string]interface{}
 	return req.FormValue(param)
 }
 
-func (r *rest2eth) subscribeEvent(res http.ResponseWriter, req *http.Request, addrStr string, abiEvent *abi.Event, body map[string]interface{}) {
+func (r *rest2eth) subscribeEvent(res http.ResponseWriter, req *http.Request, addrStr string, abiEvent *kldbind.ABIElementMarshaling, body map[string]interface{}) {
 
 	err := kldauth.AuthEventStreams(req.Context())
 	if err != nil {

--- a/internal/kldcontracts/rest2eth_test.go
+++ b/internal/kldcontracts/rest2eth_test.go
@@ -158,7 +158,7 @@ func (m *mockSubMgr) ResumeStream(ctx context.Context, id string) error {
 	return m.err
 }
 func (m *mockSubMgr) DeleteStream(ctx context.Context, id string) error { return m.err }
-func (m *mockSubMgr) AddSubscription(ctx context.Context, addr *kldbind.Address, event *kldbind.ABIEvent, streamID, initialBlock, name string) (*kldevents.SubscriptionInfo, error) {
+func (m *mockSubMgr) AddSubscription(ctx context.Context, addr *kldbind.Address, event *kldbind.ABIElementMarshaling, streamID, initialBlock, name string) (*kldevents.SubscriptionInfo, error) {
 	m.capturedAddr = addr
 	return m.sub, m.err
 }
@@ -171,9 +171,8 @@ func (m *mockSubMgr) Close()                                                  {}
 
 func newTestDeployMsg(addr string) *deployContractWithAddress {
 	compiled, _ := kldeth.CompileContract(simpleEventsSource(), "SimpleEvents", "", "")
-	a := &kldbind.ABI{ABI: *compiled.ABI}
 	return &deployContractWithAddress{
-		DeployContract: kldmessages.DeployContract{ABI: a},
+		DeployContract: kldmessages.DeployContract{ABI: compiled.ABI},
 		Address:        addr,
 	}
 }

--- a/internal/kldcontracts/rest2eth_test.go
+++ b/internal/kldcontracts/rest2eth_test.go
@@ -935,6 +935,29 @@ func TestSendTransactionBadConstructorABI(t *testing.T) {
 	assert.Equal("Invalid method 'constructor' in ABI: unsupported arg type: badness", reply.Message)
 }
 
+func TestSendTransactionDefaultConstructorABI(t *testing.T) {
+	assert := assert.New(t)
+	dir := tempdir()
+	defer cleanup(dir)
+	dispatcher := &mockREST2EthDispatcher{
+		asyncDispatchReply: &kldmessages.AsyncSentMsg{
+			Sent:    true,
+			Request: "request1",
+		},
+	}
+	abiLoader := &mockABILoader{
+		deployMsg: &kldmessages.DeployContract{
+			ABI: kldbind.ABIMarshaling{}, // completely empty ABI is ok
+		},
+	}
+	_, _, router := newTestREST2EthCustomAbiLoader(dispatcher, abiLoader)
+	req := httptest.NewRequest("POST", "/abis/testabi", bytes.NewReader([]byte{}))
+	req.Header.Add("x-kaleido-from", "0x66c5fe653e7a9ebb628a6d40f0452d1e358baee8")
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+	assert.Equal(202, res.Result().StatusCode)
+}
+
 func TestSendTransactionBadFrom(t *testing.T) {
 	assert := assert.New(t)
 	dir := tempdir()

--- a/internal/kldcontracts/smartcontractgw_test.go
+++ b/internal/kldcontracts/smartcontractgw_test.go
@@ -211,6 +211,16 @@ func TestPreDeployCompileAndPostDeploy(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal("SimpleEvents", swagger.Info.Title)
 
+	// Check we can get the full ABI back over REST
+	req = httptest.NewRequest("GET", "/abis/message1?abi", bytes.NewReader([]byte{}))
+	res = httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+	assert.Equal(200, res.Result().StatusCode)
+	var abi kldbind.RuntimeABI
+	err = json.NewDecoder(res.Body).Decode(&abi)
+	assert.NoError(err)
+	assert.Equal("set", abi.Methods["set"].Name)
+
 	// Check we can get the full contract swagger back over REST with contract addr that includes 0x prefix
 	req = httptest.NewRequest("GET", "/contracts/0x0123456789abcdef0123456789abcdef01234567?swagger", bytes.NewReader([]byte{}))
 	res = httptest.NewRecorder()
@@ -228,6 +238,15 @@ func TestPreDeployCompileAndPostDeploy(t *testing.T) {
 	err = json.NewDecoder(res.Body).Decode(&swagger)
 	assert.NoError(err)
 	assert.Equal("SimpleEvents", swagger.Info.Title)
+
+	// Check we can get the full contract ABI back over REST
+	req = httptest.NewRequest("GET", "/contracts/0123456789abcdef0123456789abcdef01234567?abi", bytes.NewReader([]byte{}))
+	res = httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+	assert.Equal(200, res.Result().StatusCode)
+	err = json.NewDecoder(res.Body).Decode(&abi)
+	assert.NoError(err)
+	assert.Equal("set", abi.Methods["set"].Name)
 
 	// Check we can get the full swagger back over REST using the registered name
 	req = httptest.NewRequest("GET", "/contracts/Test+1?ui&from=0x0123456789abcdef0123456789abcdef01234567", bytes.NewReader([]byte{}))
@@ -339,6 +358,14 @@ func TestRemoteRegistrySwaggerOrABI(t *testing.T) {
 	assert.Equal(200, res.Code)
 	json.NewDecoder(res.Body).Decode(&returnedSwagger)
 	assert.Equal("/api/v1/g/test", returnedSwagger.BasePath)
+
+	req = httptest.NewRequest("GET", "/g/test?abi", bytes.NewReader([]byte{}))
+	res = httptest.NewRecorder()
+	router.ServeHTTP(res, req)
+	var returnedABI kldbind.RuntimeABI
+	assert.Equal(200, res.Code)
+	json.NewDecoder(res.Body).Decode(&returnedABI)
+	assert.Equal("set", returnedABI.Methods["set"].Name)
 
 	req = httptest.NewRequest("GET", "/i/test?openapi", bytes.NewReader([]byte{}))
 	res = httptest.NewRecorder()

--- a/internal/kldcontracts/smartcontractgw_test.go
+++ b/internal/kldcontracts/smartcontractgw_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kaleido-io/ethconnect/internal/kldbind"
+
 	"github.com/kaleido-io/ethconnect/internal/kldauth"
 	"github.com/kaleido-io/ethconnect/internal/kldauth/kldauthtest"
 
@@ -172,7 +174,9 @@ func TestPreDeployCompileAndPostDeploy(t *testing.T) {
 	deployMsg, abiID, err := scgw.(*smartContractGW).loadDeployMsgForInstance("0123456789abcdef0123456789abcdef01234567")
 	assert.NoError(err)
 	assert.NotEmpty(abiID)
-	assert.Equal("set", deployMsg.ABI.Methods["set"].Name)
+	runtimeABI, err := kldbind.ABIMarshalingToABIRuntime(deployMsg.ABI)
+	assert.NoError(err)
+	assert.Equal("set", runtimeABI.Methods["set"].Name)
 
 	// Check we can list it back over REST
 	router := &httprouter.Router{}

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -239,6 +239,10 @@ const (
 	RESTGatewaySyncWrapErrorWithTXDetail = "TX %s: %s"
 	// RESTGatewayMethodTypeInvalid unsupported method type
 	RESTGatewayMethodTypeInvalid = "Unsupported method type: %s"
+	// RESTGatewayMethodABIInvalid error processing method from ABI
+	RESTGatewayMethodABIInvalid = "Unsupported method '%s' in ABI: %s"
+	// RESTGatewayEventABIInvalid error processing method from ABI
+	RESTGatewayEventABIInvalid = "Unsupported event '%s' in ABI: %s"
 
 	// RESTGatewayCompileContractInvalidFormData invalid form data when requesting a compilation to generate an ABI/bytecode
 	RESTGatewayCompileContractInvalidFormData = "Could not parse supplied multi-part form data: %s"
@@ -281,6 +285,8 @@ const (
 	RESTGatewayLocalStoreABIParse = "Failed to parse ABI with ID %s: %s"
 	// RESTGatewayLocalStoreMissingABI did not supply ABI JSON when attempting to install ABI (non-registry code flow)
 	RESTGatewayLocalStoreMissingABI = "Must supply ABI to install an existing ABI into the REST Gateway"
+	// RESTGatewayInvalidABI invalid serialized ABI in msg
+	RESTGatewayInvalidABI = "Invalid ABI: %s"
 	// RESTGatewayLocalStoreContractSavePostDeploy local filesystem storage failure for contract instance post deploy (non-registry code flow)
 	RESTGatewayLocalStoreContractSavePostDeploy = "%s: Failed to write deployment details: %s"
 	// RESTGatewayFriendlyNameClash duplicate friendly name when reigstering

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -240,9 +240,9 @@ const (
 	// RESTGatewayMethodTypeInvalid unsupported method type
 	RESTGatewayMethodTypeInvalid = "Unsupported method type: %s"
 	// RESTGatewayMethodABIInvalid error processing method from ABI
-	RESTGatewayMethodABIInvalid = "Unsupported method '%s' in ABI: %s"
+	RESTGatewayMethodABIInvalid = "Invalid method '%s' in ABI: %s"
 	// RESTGatewayEventABIInvalid error processing method from ABI
-	RESTGatewayEventABIInvalid = "Unsupported event '%s' in ABI: %s"
+	RESTGatewayEventABIInvalid = "Invalid event '%s' in ABI: %s"
 
 	// RESTGatewayCompileContractInvalidFormData invalid form data when requesting a compilation to generate an ABI/bytecode
 	RESTGatewayCompileContractInvalidFormData = "Could not parse supplied multi-part form data: %s"

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -377,7 +377,7 @@ const (
 	// TransactionSendInputTooManyParams more parameters provided than specified on ABI
 	TransactionSendInputTooManyParams = "Supplied %d paramters for ABI that supports %d"
 	// TransactionSendInputNotAssignable if we end up in a situation where the generated type cannot be assigned
-	TransactionSendInputNotAssignable = "Method %s param %s: supplied value '%+v' could not be assigned to '%s' field"
+	TransactionSendInputNotAssignable = "Method %s param %s: supplied value '%+v' could not be assigned to '%s' field (%s)"
 
 	// TransactionSendReceiptCheckError we continually had bad RCs back from the node while trying to check for the receipt up to the timeout
 	TransactionSendReceiptCheckError = "Error obtaining transaction receipt (%d retries): %s"

--- a/internal/kldeth/compiler.go
+++ b/internal/kldeth/compiler.go
@@ -23,10 +23,11 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/kaleido-io/ethconnect/internal/kldbind"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common/compiler"
 	"github.com/kaleido-io/ethconnect/internal/klderrors"
 )
@@ -41,7 +42,7 @@ type CompiledSolidity struct {
 	ContractName string
 	Compiled     []byte
 	DevDoc       string
-	ABI          *abi.ABI
+	ABI          kldbind.ABIMarshaling
 	ContractInfo *compiler.ContractInfo
 }
 
@@ -164,11 +165,12 @@ func packContract(contractName string, contract *compiler.Contract) (c *Compiled
 	if err != nil {
 		return nil, klderrors.Errorf(klderrors.CompilerABISerialize, err)
 	}
-	abi, err := abi.JSON(bytes.NewReader(abiJSON))
+	var abi kldbind.ABIMarshaling
+	err = json.Unmarshal(abiJSON, &abi)
 	if err != nil {
 		return nil, klderrors.Errorf(klderrors.CompilerABIReRead, err)
 	}
-	c.ABI = &abi
+	c.ABI = abi
 	devdocBytes, err := json.Marshal(contract.Info.DeveloperDoc)
 	if err != nil {
 		return nil, klderrors.Errorf(klderrors.CompilerSerializeDevDocs, err)

--- a/internal/kldeth/compiler_test.go
+++ b/internal/kldeth/compiler_test.go
@@ -51,6 +51,15 @@ func TestPackContractFailBadHexCode(t *testing.T) {
 	assert.EqualError(err, "Decoding bytecode: hex string without 0x prefix")
 }
 
+func TestPackContractEmpty(t *testing.T) {
+	assert := assert.New(t)
+	contract := &compiler.Contract{
+		Code: "0x",
+	}
+	_, err := packContract("", contract)
+	assert.EqualError(err, "Specified contract compiled ok, but did not result in any bytecode: ")
+}
+
 func TestPackContractFailMarshalABI(t *testing.T) {
 	assert := assert.New(t)
 	contract := &compiler.Contract{

--- a/internal/kldeth/txn.go
+++ b/internal/kldeth/txn.go
@@ -16,7 +16,6 @@ package kldeth
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -29,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
+	"github.com/kaleido-io/ethconnect/internal/kldbind"
 	"github.com/kaleido-io/ethconnect/internal/klderrors"
 	"github.com/kaleido-io/ethconnect/internal/kldmessages"
 	"github.com/kaleido-io/ethconnect/internal/kldutils"
@@ -77,7 +77,7 @@ func NewContractDeployTxn(msg *kldmessages.DeployContract, signer TXSigner) (tx 
 	if msg.Compiled != nil && msg.ABI != nil {
 		compiled = &CompiledSolidity{
 			Compiled: msg.Compiled,
-			ABI:      &msg.ABI.ABI,
+			ABI:      msg.ABI,
 		}
 	} else if msg.Solidity != "" {
 		// Compile the solidity contract
@@ -89,14 +89,19 @@ func NewContractDeployTxn(msg *kldmessages.DeployContract, signer TXSigner) (tx 
 		return
 	}
 
-	// Build correctly typed args for the ethereum call
-	typedArgs, err := tx.generateTypedArgs(msg.Parameters, &compiled.ABI.Constructor)
+	// Build a runtime ABI from the serialized one
+	var typedArgs []interface{}
+	abi, err := kldbind.ABIMarshalingToABIRuntime(compiled.ABI)
+	if err == nil {
+		// Build correctly typed args for the ethereum call
+		typedArgs, err = tx.generateTypedArgs(msg.Parameters, &abi.Constructor)
+	}
 	if err != nil {
 		return
 	}
 
 	// Pack the arguments
-	packedCall, err := compiled.ABI.Pack("", typedArgs...)
+	packedCall, err := abi.Pack("", typedArgs...)
 	if err != nil {
 		err = klderrors.Errorf(klderrors.TransactionSendConstructorPackArgs, err)
 		return
@@ -123,7 +128,7 @@ func NewContractDeployTxn(msg *kldmessages.DeployContract, signer TXSigner) (tx 
 }
 
 // CallMethod performs eth_call to return data from the chain
-func CallMethod(ctx context.Context, rpc RPCClient, signer TXSigner, from, addr string, value json.Number, methodABI *abi.Method, msgParams []interface{}, blocknumber string) (map[string]interface{}, error) {
+func CallMethod(ctx context.Context, rpc RPCClient, signer TXSigner, from, addr string, value json.Number, methodABI *kldbind.ABIMethod, msgParams []interface{}, blocknumber string) (map[string]interface{}, error) {
 	log.Debugf("Calling method: %+v %+v", methodABI, msgParams)
 	tx, err := buildTX(signer, from, addr, "", value, "", "", methodABI, msgParams)
 	if err != nil {
@@ -147,34 +152,26 @@ func CallMethod(ctx context.Context, rpc RPCClient, signer TXSigner, from, addr 
 	}
 
 	retBytes, err := tx.Call(ctx, rpc, callOption)
-	if err != nil {
+	if err != nil || retBytes == nil {
 		return nil, err
 	}
-	if retBytes == nil {
-		return nil, nil
-	}
 	return ProcessRLPBytes(methodABI.Outputs, retBytes)
-}
-
-func addErrorToRetval(retval map[string]interface{}, retBytes []byte, rawRetval interface{}, err error) {
-	log.Warnf(err.Error())
-	retval["rlp"] = hex.EncodeToString(retBytes)
-	retval["raw"] = rawRetval
-	retval["error"] = err.Error()
 }
 
 // ProcessRLPBytes converts binary packed set of bytes into a map
 func ProcessRLPBytes(args abi.Arguments, retBytes []byte) (map[string]interface{}, error) {
 	retval := make(map[string]interface{})
-	rawRetval, err := args.UnpackValues(retBytes)
+	rawRetval, unpackErr := args.UnpackValues(retBytes)
+	var err error
+	if unpackErr != nil {
+		err = klderrors.Errorf(klderrors.UnpackOutputsFailed, unpackErr)
+	} else {
+		err = processOutputs(args, rawRetval, retval)
+	}
 	if err != nil {
-		addErrorToRetval(retval, retBytes, rawRetval, klderrors.Errorf(klderrors.UnpackOutputsFailed, err))
-		return nil, err
+		log.Errorf("Unabled to process bytes '%s': %s", rawRetval, err)
 	}
-	if err = processOutputs(args, rawRetval, retval); err != nil {
-		addErrorToRetval(retval, retBytes, rawRetval, err)
-	}
-	return retval, nil
+	return retval, err
 }
 
 func processOutputs(args abi.Arguments, rawRetval []interface{}, retval map[string]interface{}) error {
@@ -188,7 +185,7 @@ func processOutputs(args abi.Arguments, rawRetval []interface{}, retval map[stri
 				return err
 			}
 		}
-	} else if rawRetval != nil {
+	} else if len(rawRetval) > 0 {
 		return klderrors.Errorf(klderrors.UnpackOutputsMismatchNil, rawRetval)
 	}
 	return nil

--- a/internal/kldeth/txn.go
+++ b/internal/kldeth/txn.go
@@ -169,7 +169,7 @@ func ProcessRLPBytes(args abi.Arguments, retBytes []byte) (map[string]interface{
 		err = processOutputs(args, rawRetval, retval)
 	}
 	if err != nil {
-		log.Errorf("Unabled to process bytes '%s': %s", rawRetval, err)
+		log.Errorf("Unable to process bytes '%s': %s", rawRetval, err)
 	}
 	return retval, err
 }

--- a/internal/kldeth/txn.go
+++ b/internal/kldeth/txn.go
@@ -185,7 +185,7 @@ func processOutputs(args abi.Arguments, rawRetval []interface{}, retval map[stri
 				return err
 			}
 		}
-	} else if len(rawRetval) > 0 {
+	} else if rawRetval != nil {
 		return klderrors.Errorf(klderrors.UnpackOutputsMismatchNil, rawRetval)
 	}
 	return nil

--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -1632,12 +1632,37 @@ func TestProcessRLPV2ABIEncodedStructsBadInputType(t *testing.T) {
 	}
 
 	input1Map := map[string]interface{}{
+		"str1":   "ok",
+		"val1":   "12345",
 		"nested": "Not a map",
 	}
 
 	tx := Txn{}
 	_, err = tx.generateTypedArgs([]interface{}{input1Map}, &abiMethod)
 	assert.EqualError(err, "Method 'inOutType1' param 0.nested is a (string,string,address,bytes): Must supply an object (supplied=string)")
+}
+
+func TestProcessRLPV2ABIEncodedStructsBadNilType(t *testing.T) {
+	assert := assert.New(t)
+
+	var v2abi abi.ABI
+	testABIInput, err := ioutil.ReadFile("../../test/abicoderv2_example.abi.json")
+	assert.NoError(err)
+	err = json.Unmarshal(testABIInput, &v2abi)
+	assert.NoError(err)
+
+	var abiMethod abi.Method
+	for _, m := range v2abi.Methods {
+		if m.Name == "inOutType1" {
+			abiMethod = m
+		}
+	}
+
+	input1Map := map[string]interface{}{}
+
+	tx := Txn{}
+	_, err = tx.generateTypedArgs([]interface{}{input1Map}, &abiMethod)
+	assert.EqualError(err, "Method inOutType1 param 0: supplied value '<nil>' could not be assigned to 'str1' field (string)")
 }
 
 func TestGenerateTupleFromMapBadStructType(t *testing.T) {
@@ -1650,7 +1675,7 @@ func TestGenerateTupleFromMapBadStructType(t *testing.T) {
 		TupleRawNames: []string{"field1"},
 		TupleElems:    []*abi.Type{&tUint},
 	}, map[string]interface{}{"field1": float64(42)})
-	assert.EqualError(err, "Method method1 param test: supplied value '+42' could not be assigned to 'field1' field")
+	assert.EqualError(err, "Method method1 param test: supplied value '+42' could not be assigned to 'field1' field (uint256)")
 }
 
 func TestGenTupleMapOutputBadTypeNonStruct(t *testing.T) {

--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -59,8 +59,8 @@ func (r *testRPCClient) CallContext(ctx context.Context, result interface{}, met
 }
 
 const (
-	simpleStorage = "pragma solidity >=0.4.22 <0.6.9;\n\ncontract simplestorage {\nuint public storedData;\n\nconstructor(uint initVal) public {\nstoredData = initVal;\n}\n\nfunction set(uint x) public {\nstoredData = x;\n}\n\nfunction get() public view returns (uint retVal) {\nreturn storedData;\n}\n}"
-	twoContracts  = "pragma solidity >=0.4.22 <0.6.9;\n\ncontract contract1 {function f1() public pure returns (uint retVal) {\nreturn 1;\n}\n}\n\ncontract contract2 {function f2() public pure returns (uint retVal) {\nreturn 2;\n}\n}"
+	simpleStorage = "pragma solidity >=0.4.22 <0.7;\n\ncontract simplestorage {\nuint public storedData;\n\nconstructor(uint initVal) public {\nstoredData = initVal;\n}\n\nfunction set(uint x) public {\nstoredData = x;\n}\n\nfunction get() public view returns (uint retVal) {\nreturn storedData;\n}\n}"
+	twoContracts  = "pragma solidity >=0.4.22 <0.7;\n\ncontract contract1 {function f1() public pure returns (uint retVal) {\nreturn 1;\n}\n}\n\ncontract contract2 {function f2() public pure returns (uint retVal) {\nreturn 2;\n}\n}"
 )
 
 func TestNewContractDeployTxnSimpleStorage(t *testing.T) {
@@ -262,13 +262,12 @@ func TestNewContractDeployMissingCompiledOrSolidity(t *testing.T) {
 func TestNewContractDeployPrecompiledSimpleStorage(t *testing.T) {
 	assert := assert.New(t)
 
-	c, _ := CompileContract(simpleStorage, "simplestorage", "", "")
+	c, err := CompileContract(simpleStorage, "simplestorage", "", "")
+	assert.NoError(err)
 
 	var msg kldmessages.DeployContract
 	msg.Compiled = c.Compiled
-	msg.ABI = &kldbind.ABI{
-		ABI: *c.ABI,
-	}
+	msg.ABI = c.ABI
 	msg.Parameters = []interface{}{float64(999999)}
 	msg.From = "0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c"
 	msg.Nonce = "123"
@@ -447,7 +446,7 @@ func testComplexParam(t *testing.T, solidityType string, val interface{}, expect
 	assert := assert.New(t)
 
 	var msg kldmessages.DeployContract
-	msg.Solidity = "pragma solidity >=0.4.22 <0.6.9; contract test {constructor(" + solidityType + " p1) public {}}"
+	msg.Solidity = "pragma solidity >=0.4.22 <0.7; contract test {constructor(" + solidityType + " p1) public {}}"
 	msg.Parameters = []interface{}{val}
 	msg.From = "0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c"
 	msg.Nonce = "123"

--- a/internal/kldevents/eventstream_test.go
+++ b/internal/kldevents/eventstream_test.go
@@ -403,31 +403,31 @@ func setupTestSubscription(assert *assert.Assertions, sm *subscriptionMGR, strea
 	})
 	sm.rpc = rpc
 
-	event := &kldbind.ABIEvent{
+	event := &kldbind.ABIElementMarshaling{
 		Name: "Changed",
-		Inputs: []kldbind.ABIArgument{
+		Inputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name:    "from",
-				Type:    kldbind.ABITypeKnown("address"),
+				Type:    "address",
 				Indexed: true,
 			},
 			{
 				Name:    "i",
-				Type:    kldbind.ABITypeKnown("int64"),
+				Type:    "int64",
 				Indexed: true,
 			},
 			{
 				Name:    "s",
-				Type:    kldbind.ABITypeKnown("string"),
+				Type:    "string",
 				Indexed: true,
 			},
 			{
 				Name: "h",
-				Type: kldbind.ABITypeKnown("bytes32"),
+				Type: "bytes32",
 			},
 			{
 				Name: "m",
-				Type: kldbind.ABITypeKnown("string"),
+				Type: "string",
 			},
 		},
 	}

--- a/internal/kldevents/logprocessor_test.go
+++ b/internal/kldevents/logprocessor_test.go
@@ -67,7 +67,7 @@ func TestProcessLogEntryNillAndTooFewFields(t *testing.T) {
     "anonymous": true,
     "inputs": [
       {"name": "one", "type": "uint256", "indexed": true},
-      {"name": "two", "type": "uint256", "indexed": true},
+      {"name": "two", "type": "uint256", "indexed": true}
     ]
   }`
 	var marshaling kldbind.ABIElementMarshaling

--- a/internal/kldevents/submanager.go
+++ b/internal/kldevents/submanager.go
@@ -53,7 +53,7 @@ type SubscriptionManager interface {
 	SuspendStream(ctx context.Context, id string) error
 	ResumeStream(ctx context.Context, id string) error
 	DeleteStream(ctx context.Context, id string) error
-	AddSubscription(ctx context.Context, addr *kldbind.Address, event *kldbind.ABIEvent, streamID, initialBlock, name string) (*SubscriptionInfo, error)
+	AddSubscription(ctx context.Context, addr *kldbind.Address, event *kldbind.ABIElementMarshaling, streamID, initialBlock, name string) (*SubscriptionInfo, error)
 	Subscriptions(ctx context.Context) []*SubscriptionInfo
 	SubscriptionByID(ctx context.Context, id string) (*SubscriptionInfo, error)
 	DeleteSubscription(ctx context.Context, id string) error
@@ -126,13 +126,13 @@ func (s *subscriptionMGR) Subscriptions(ctx context.Context) []*SubscriptionInfo
 }
 
 // AddSubscription adds a new subscription
-func (s *subscriptionMGR) AddSubscription(ctx context.Context, addr *kldbind.Address, event *kldbind.ABIEvent, streamID, initialBlock, name string) (*SubscriptionInfo, error) {
+func (s *subscriptionMGR) AddSubscription(ctx context.Context, addr *kldbind.Address, event *kldbind.ABIElementMarshaling, streamID, initialBlock, name string) (*SubscriptionInfo, error) {
 	i := &SubscriptionInfo{
 		TimeSorted: kldmessages.TimeSorted{
 			CreatedISO8601: time.Now().UTC().Format(time.RFC3339),
 		},
 		ID:     subIDPrefix + kldutils.UUIDv4(),
-		Event:  kldbind.MarshalledABIEvent{E: *event},
+		Event:  event,
 		Stream: streamID,
 	}
 	i.Path = SubPathPrefix + "/" + i.ID

--- a/internal/kldevents/submanager_test.go
+++ b/internal/kldevents/submanager_test.go
@@ -124,7 +124,7 @@ func TestActionAndSubscriptionLifecyle(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	sub, err := sm.AddSubscription(ctx, nil, &kldbind.ABIEvent{Name: "ping"}, stream.ID, "", subscriptionName)
+	sub, err := sm.AddSubscription(ctx, nil, &kldbind.ABIElementMarshaling{Name: "ping"}, stream.ID, "", subscriptionName)
 	assert.NoError(err)
 	assert.Equal(stream.ID, sub.Stream)
 
@@ -196,7 +196,7 @@ func TestActionChildCleanup(t *testing.T) {
 	})
 	assert.NoError(err)
 
-	sm.AddSubscription(ctx, nil, &kldbind.ABIEvent{Name: "ping"}, stream.ID, "12345", "")
+	sm.AddSubscription(ctx, nil, &kldbind.ABIElementMarshaling{Name: "ping"}, stream.ID, "12345", "")
 	err = sm.DeleteStream(ctx, stream.ID)
 	assert.NoError(err)
 
@@ -232,11 +232,11 @@ func TestStreamAndSubscriptionErrors(t *testing.T) {
 	err = sm.DeleteStream(ctx, "teststream")
 	assert.EqualError(err, "pop")
 
-	_, err = sm.AddSubscription(ctx, nil, &kldbind.ABIEvent{Name: "any"}, "nope", "", "")
+	_, err = sm.AddSubscription(ctx, nil, &kldbind.ABIElementMarshaling{Name: "any"}, "nope", "", "")
 	assert.EqualError(err, "Stream with ID 'nope' not found")
-	_, err = sm.AddSubscription(ctx, nil, &kldbind.ABIEvent{Name: "any"}, "teststream", "", "test")
+	_, err = sm.AddSubscription(ctx, nil, &kldbind.ABIElementMarshaling{Name: "any"}, "teststream", "", "test")
 	assert.EqualError(err, "Failed to store subscription: pop")
-	_, err = sm.AddSubscription(ctx, nil, &kldbind.ABIEvent{Name: "any"}, "teststream", "!bad integer", "")
+	_, err = sm.AddSubscription(ctx, nil, &kldbind.ABIElementMarshaling{Name: "any"}, "teststream", "!bad integer", "")
 	assert.EqualError(err, "FromBlock cannot be parsed as a BigInt")
 	sm.subscriptions["testsub"] = &subscription{info: &SubscriptionInfo{}, rpc: sm.rpc}
 	err = sm.DeleteSubscription(ctx, "nope")

--- a/internal/kldmessages/messages.go
+++ b/internal/kldmessages/messages.go
@@ -145,15 +145,15 @@ type SendTransaction struct {
 // DeployContract message instructs the bridge to install a contract
 type DeployContract struct {
 	TransactionCommon
-	Solidity        string       `json:"solidity,omitempty"`
-	CompilerVersion string       `json:"compilerVersion,omitempty"`
-	EVMVersion      string       `json:"evmVersion,omitempty"`
-	ABI             *kldbind.ABI `json:"abi,omitempty"`
-	DevDoc          string       `json:"devDocs,omitempty"`
-	Compiled        []byte       `json:"compiled,omitempty"`
-	ContractName    string       `json:"contractName,omitempty"`
-	Description     string       `json:"description,omitempty"`
-	RegisterAs      string       `json:"registerAs,omitempty"`
+	Solidity        string                `json:"solidity,omitempty"`
+	CompilerVersion string                `json:"compilerVersion,omitempty"`
+	EVMVersion      string                `json:"evmVersion,omitempty"`
+	ABI             kldbind.ABIMarshaling `json:"abi,omitempty"`
+	DevDoc          string                `json:"devDocs,omitempty"`
+	Compiled        []byte                `json:"compiled,omitempty"`
+	ContractName    string                `json:"contractName,omitempty"`
+	Description     string                `json:"description,omitempty"`
+	RegisterAs      string                `json:"registerAs,omitempty"`
 }
 
 // TransactionReceipt is sent when a transaction has been successfully mined

--- a/internal/kldrest/webhookskafka_test.go
+++ b/internal/kldrest/webhookskafka_test.go
@@ -374,7 +374,7 @@ func TestWebhookHandlerYAMLDeployContract(t *testing.T) {
 		"  type: DeployContract\n" +
 		"from: '0x4b098809E68C88e26442491c57866b7D4852216c'\n" +
 		"solidity: |-\n" +
-		"  pragma solidity >=0.4.22 <0.6.9;\n" +
+		"  pragma solidity >=0.4.22 <0.7;\n" +
 		"  \n" +
 		"  contract simplestorage {\n" +
 		"    uint public storedData;\n" +

--- a/internal/kldtx/txnprocessor_test.go
+++ b/internal/kldtx/txnprocessor_test.go
@@ -78,7 +78,7 @@ const testFromAddr = "0x83dBC8e329b38cBA0Fc4ed99b1Ce9c2a390ABdC1"
 
 var goodDeployTxnJSON = "{" +
 	"  \"headers\":{\"type\": \"DeployContract\"}," +
-	"  \"solidity\":\"pragma solidity >=0.4.22 <0.6.9; contract t {constructor() public {}}\"," +
+	"  \"solidity\":\"pragma solidity >=0.4.22 <0.7; contract t {constructor() public {}}\"," +
 	"  \"from\":\"" + testFromAddr + "\"," +
 	"  \"nonce\":\"123\"," +
 	"  \"gas\":\"123\"" +
@@ -86,7 +86,7 @@ var goodDeployTxnJSON = "{" +
 
 var goodHDWalletDeployTxnJSON = "{" +
 	"  \"headers\":{\"type\": \"DeployContract\"}," +
-	"  \"solidity\":\"pragma solidity >=0.4.22 <0.6.9; contract t {constructor() public {}}\"," +
+	"  \"solidity\":\"pragma solidity >=0.4.22 <0.7; contract t {constructor() public {}}\"," +
 	"  \"from\":\"hd-testinst-testwallet-1234\"," +
 	"  \"nonce\":\"123\"," +
 	"  \"gas\":\"123\"" +
@@ -101,7 +101,7 @@ var goodSendTxnJSON = "{" +
 
 var goodDeployTxnPrivateJSON = "{" +
 	"  \"headers\":{\"type\": \"DeployContract\"}," +
-	"  \"solidity\":\"pragma solidity >=0.4.22 <0.6.9; contract t {constructor() public {}}\"," +
+	"  \"solidity\":\"pragma solidity >=0.4.22 <0.7; contract t {constructor() public {}}\"," +
 	"  \"from\":\"" + testFromAddr + "\"," +
 	"  \"nonce\":\"123\"," +
 	"  \"gas\":\"123\"," +

--- a/test/simpleevents.sol
+++ b/test/simpleevents.sol
@@ -1,4 +1,4 @@
- pragma solidity >=0.5.2 <0.6.9;
+ pragma solidity >=0.5.2 <0.7;
 /**
   * @title Simple Storage with events
   * @dev Read and write values to the chain


### PR DESCRIPTION
So I found a pretty big issue, that took a while to work around - and sadly quite a lot more code change.

The `abi.ABI` interface and its children in go-ethereum provided `Unmarshal`, but does not provide `Marshal`.
Before we had worked around that by providing my own custom `Marshal` interface, that simply to the external fields of the go-ethereum objects and serialized them.

Sadly when the structures were updated to add the `components` and `internalType` extensions, these fields in their original form get thrown away during the `Unmarshal`:

https://github.com/ethereum/go-ethereum/blob/f5382591874220287de253bfc08b10afd5244927/accounts/abi/argument.go#L36-L60

This meant I had to find a solution to allow the code to serialize and de-serialize the original JSON, while also no re-implementing all of the complex type implementation that is super useful within the go-ethereum `abi.Type` interface.

I settled on moving all the code to using our own simple `ABIMarshaling` structure that represents the raw JSON, then just in time conversion into `abi.Method` / `abi.Event` when we want the full type structures.
Even with this compromise the change was quite extensive.

I also found some gotchas when testing end-to-end with real nested input output structures, and addressed those