### PR TITLE
Fix how ABI serializes down into Kafka message

### DIFF
--- a/internal/kldbind/typeutils.go
+++ b/internal/kldbind/typeutils.go
@@ -119,9 +119,10 @@ func ABIElementMarshalingToABIEvent(marshalable *ABIElementMarshaling) (event *A
 // ABIElementMarshalingToABIMethod converts a de-serialized method with full type information,
 // per the original ABI, into a runtime ABIEvent with a processed type
 func ABIElementMarshalingToABIMethod(m *ABIElementMarshaling) (method *ABIMethod, err error) {
-	inputs, err := ABIArgumentsMarshalingToABIArguments(m.Inputs)
+	var inputs, outputs ABIArguments
+	inputs, err = ABIArgumentsMarshalingToABIArguments(m.Inputs)
 	if err == nil {
-		outputs, err := ABIArgumentsMarshalingToABIArguments(m.Outputs)
+		outputs, err = ABIArgumentsMarshalingToABIArguments(m.Outputs)
 		if err == nil {
 			nMethod := abi.NewMethod(m.Name, m.Name, abi.Function, m.StateMutability, m.Constant, m.Payable, inputs, outputs)
 			method = &nMethod

--- a/internal/kldeth/txn.go
+++ b/internal/kldeth/txn.go
@@ -304,7 +304,7 @@ func NewSendTxn(msg *kldmessages.SendTransaction, signer TXSigner) (tx *Txn, err
 			return
 		}
 		var abiInputs abi.Arguments
-		jsonABI := &kldmessages.ABIMethod{
+		jsonABI := &kldbind.ABIElementMarshaling{
 			Name:    msg.MethodName,
 			Inputs:  []kldbind.ABIArgumentMarshaling{},
 			Outputs: []kldbind.ABIArgumentMarshaling{},
@@ -377,7 +377,7 @@ func buildTX(signer TXSigner, msgFrom, msgTo string, msgNonce, msgValue, msgGas,
 	return
 }
 
-func genMethodABI(jsonABI *kldmessages.ABIMethod, predeterminedInputs abi.Arguments) (method *abi.Method, err error) {
+func genMethodABI(jsonABI *kldbind.ABIElementMarshaling, predeterminedInputs abi.Arguments) (method *abi.Method, err error) {
 	var inputs abi.Arguments
 	if predeterminedInputs != nil {
 		inputs = predeterminedInputs

--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -1318,15 +1318,15 @@ func TestSendTxnBadInputType(t *testing.T) {
 	assert := assert.New(t)
 
 	var msg kldmessages.SendTransaction
-	msg.Method = &kldmessages.ABIMethod{
+	msg.Method = &kldbind.ABIElementMarshaling{
 		Name: "testFunc",
-		Inputs: []kldmessages.ABIParam{
+		Inputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "param1",
 				Type: "badness",
 			},
 		},
-		Outputs: []kldmessages.ABIParam{
+		Outputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "ret1",
 				Type: "uint256",
@@ -1334,7 +1334,7 @@ func TestSendTxnBadInputType(t *testing.T) {
 		},
 	}
 	_, err := NewSendTxn(&msg, nil)
-	assert.Regexp("ABI input 0: Unable to map param1 to etherueum type: unsupported arg type:", err.Error())
+	assert.Regexp("unsupported arg type: badness", err.Error())
 }
 
 func TestSendTxnMissingMethod(t *testing.T) {
@@ -1416,15 +1416,15 @@ func TestSendTxnBadOutputType(t *testing.T) {
 	assert := assert.New(t)
 
 	var msg kldmessages.SendTransaction
-	msg.Method = &kldmessages.ABIMethod{
+	msg.Method = &kldbind.ABIElementMarshaling{
 		Name: "testFunc",
-		Inputs: []kldmessages.ABIParam{
+		Inputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "param1",
 				Type: "uint256",
 			},
 		},
-		Outputs: []kldmessages.ABIParam{
+		Outputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "ret1",
 				Type: "badness",
@@ -1432,7 +1432,7 @@ func TestSendTxnBadOutputType(t *testing.T) {
 		},
 	}
 	_, err := NewSendTxn(&msg, nil)
-	assert.Regexp("ABI output 0: Unable to map ret1 to etherueum type: unsupported arg type:", err.Error())
+	assert.Regexp("unsupported arg type: badness", err.Error())
 }
 
 func TestSendBadParams(t *testing.T) {
@@ -1440,15 +1440,15 @@ func TestSendBadParams(t *testing.T) {
 
 	var msg kldmessages.SendTransaction
 	msg.Parameters = []interface{}{"abc"}
-	msg.Method = &kldmessages.ABIMethod{
+	msg.Method = &kldbind.ABIElementMarshaling{
 		Name: "testFunc",
-		Inputs: []kldmessages.ABIParam{
+		Inputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "param1",
 				Type: "int8",
 			},
 		},
-		Outputs: []kldmessages.ABIParam{
+		Outputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "ret1",
 				Type: "uint256",
@@ -1464,15 +1464,15 @@ func TestSendTxnPackError(t *testing.T) {
 
 	var msg kldmessages.SendTransaction
 	msg.Parameters = []interface{}{""}
-	msg.Method = &kldmessages.ABIMethod{
+	msg.Method = &kldbind.ABIElementMarshaling{
 		Name: "testFunc",
-		Inputs: []kldmessages.ABIParam{
+		Inputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "param1",
 				Type: "bytes1",
 			},
 		},
-		Outputs: []kldmessages.ABIParam{
+		Outputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "ret1",
 				Type: "uint256",

--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -583,9 +583,9 @@ func TestSendTxnABIParam(t *testing.T) {
 
 	var msg kldmessages.SendTransaction
 	msg.Parameters = []interface{}{"123", float64(123), "abc", "0xAA983AD2a0e0eD8ac639277F37be42F2A5d2618c", "0xfeedbeef"}
-	msg.Method = &kldmessages.ABIMethod{
+	msg.Method = &kldbind.ABIElementMarshaling{
 		Name: "testFunc",
-		Inputs: []kldmessages.ABIParam{
+		Inputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "param1",
 				Type: "uint8",
@@ -607,7 +607,7 @@ func TestSendTxnABIParam(t *testing.T) {
 				Type: "bytes",
 			},
 		},
-		Outputs: []kldmessages.ABIParam{
+		Outputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "ret1",
 				Type: "uint256",
@@ -733,7 +733,7 @@ func TestNewSendTxnMissingParamTypes(t *testing.T) {
 
 func TestGenMethodABIBadType(t *testing.T) {
 	assert := assert.New(t)
-	_, err := genMethodABI(&kldmessages.ABIMethod{
+	_, err := genMethodABI(&kldbind.ABIElementMarshaling{
 		Type: "badness",
 	}, abi.Arguments{})
 	assert.EqualError(err, "Unsupported method type: badness")
@@ -741,7 +741,7 @@ func TestGenMethodABIBadType(t *testing.T) {
 
 func TestGenMethodABIFunctionType(t *testing.T) {
 	assert := assert.New(t)
-	_, err := genMethodABI(&kldmessages.ABIMethod{
+	_, err := genMethodABI(&kldbind.ABIElementMarshaling{
 		Type: "function",
 	}, abi.Arguments{})
 	assert.NoError(err)
@@ -1232,7 +1232,7 @@ func TestSendTxnInlineBadParamType(t *testing.T) {
 	param1["type"] = "badness"
 	param1["value"] = "123"
 
-	msg.Method = &kldmessages.ABIMethod{
+	msg.Method = &kldbind.ABIElementMarshaling{
 		Name: "testFunc",
 	}
 	msg.To = "0x2b8c0ECc76d0759a8F50b2E14A6881367D805832"
@@ -1255,7 +1255,7 @@ func TestSendTxnInlineMissingParamType(t *testing.T) {
 	msg.Parameters = append(msg.Parameters, param1)
 	param1["value"] = "123"
 
-	msg.Method = &kldmessages.ABIMethod{
+	msg.Method = &kldbind.ABIElementMarshaling{
 		Name: "testFunc",
 	}
 	msg.To = "0x2b8c0ECc76d0759a8F50b2E14A6881367D805832"
@@ -1278,7 +1278,7 @@ func TestSendTxnInlineMissingParamValue(t *testing.T) {
 	msg.Parameters = append(msg.Parameters, param1)
 	param1["type"] = "uint256"
 
-	msg.Method = &kldmessages.ABIMethod{
+	msg.Method = &kldbind.ABIElementMarshaling{
 		Name: "testFunc",
 	}
 	msg.To = "0x2b8c0ECc76d0759a8F50b2E14A6881367D805832"
@@ -1302,7 +1302,7 @@ func TestSendTxnInlineBadTypeType(t *testing.T) {
 	param1["type"] = false
 	param1["value"] = "abcde"
 
-	msg.Method = &kldmessages.ABIMethod{
+	msg.Method = &kldbind.ABIElementMarshaling{
 		Name: "testFunc",
 	}
 	msg.To = "0x2b8c0ECc76d0759a8F50b2E14A6881367D805832"
@@ -1342,7 +1342,7 @@ func TestSendTxnMissingMethod(t *testing.T) {
 
 	var msg kldmessages.SendTransaction
 	msg.Parameters = []interface{}{"123"}
-	msg.Method = &kldmessages.ABIMethod{}
+	msg.Method = &kldbind.ABIElementMarshaling{}
 	msg.To = "0x2b8c0ECc76d0759a8F50b2E14A6881367D805832"
 	msg.From = "abc"
 	msg.Nonce = "123"
@@ -1357,15 +1357,15 @@ func TestSendTxnBadFrom(t *testing.T) {
 
 	var msg kldmessages.SendTransaction
 	msg.Parameters = []interface{}{"123"}
-	msg.Method = &kldmessages.ABIMethod{
+	msg.Method = &kldbind.ABIElementMarshaling{
 		Name: "testFunc",
-		Inputs: []kldmessages.ABIParam{
+		Inputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "param1",
 				Type: "uint8",
 			},
 		},
-		Outputs: []kldmessages.ABIParam{
+		Outputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "ret1",
 				Type: "uint256",
@@ -1387,15 +1387,15 @@ func TestSendTxnBadTo(t *testing.T) {
 
 	var msg kldmessages.SendTransaction
 	msg.Parameters = []interface{}{"123"}
-	msg.Method = &kldmessages.ABIMethod{
+	msg.Method = &kldbind.ABIElementMarshaling{
 		Name: "testFunc",
-		Inputs: []kldmessages.ABIParam{
+		Inputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "param1",
 				Type: "uint8",
 			},
 		},
-		Outputs: []kldmessages.ABIParam{
+		Outputs: []kldbind.ABIArgumentMarshaling{
 			{
 				Name: "ret1",
 				Type: "uint256",

--- a/internal/kldmessages/messages.go
+++ b/internal/kldmessages/messages.go
@@ -39,13 +39,6 @@ const (
 	RecordHeaderAccessToken = "kld-accesstoken"
 )
 
-// ABIMethod is the web3 form for an individual function
-// described in https://web3js.readthedocs.io/en/1.0/glossary.html
-type ABIMethod = kldbind.ABIElementMarshaling
-
-// ABIParam is an individual function parameter, for input or output, in an ABI
-type ABIParam = kldbind.ABIArgumentMarshaling
-
 // AsyncSentMsg is a standard response for async requests
 type AsyncSentMsg struct {
 	Sent    bool   `json:"sent"`

--- a/internal/kldmessages/messages.go
+++ b/internal/kldmessages/messages.go
@@ -41,21 +41,10 @@ const (
 
 // ABIMethod is the web3 form for an individual function
 // described in https://web3js.readthedocs.io/en/1.0/glossary.html
-type ABIMethod struct {
-	Type            string     `json:"type,omitempty"`
-	Name            string     `json:"name"`
-	Constant        bool       `json:"constant"`
-	Payable         bool       `json:"payable,omitempty"`
-	StateMutability string     `json:"stateMutability"`
-	Inputs          []ABIParam `json:"inputs"`
-	Outputs         []ABIParam `json:"outputs"`
-}
+type ABIMethod = kldbind.ABIElementMarshaling
 
 // ABIParam is an individual function parameter, for input or output, in an ABI
-type ABIParam struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
-}
+type ABIParam = kldbind.ABIArgumentMarshaling
 
 // AsyncSentMsg is a standard response for async requests
 type AsyncSentMsg struct {
@@ -137,9 +126,9 @@ type TransactionCommon struct {
 // SendTransaction message instructs the bridge to install a contract
 type SendTransaction struct {
 	TransactionCommon
-	To         string     `json:"to"`
-	Method     *ABIMethod `json:"method,omitempty"`
-	MethodName string     `json:"methodName,omitempty"`
+	To         string                        `json:"to"`
+	Method     *kldbind.ABIElementMarshaling `json:"method,omitempty"`
+	MethodName string                        `json:"methodName,omitempty"`
 }
 
 // DeployContract message instructs the bridge to install a contract


### PR DESCRIPTION
Now that we have hierarchical data structures being written into the intermediate message, we have to move the serialization structures across.

Due to the change made in #81 we lost a previous half-way house where we were serializing the type directly into the message alongside the value, and setting `methodName` (rather than the full `method` ABI). That approach does not scale to the deeply nested structures we need to now support.