### PR TITLE
Add call support for HD Wallet from addresses in gateway

### DIFF
--- a/internal/kldcontracts/rest2eth_test.go
+++ b/internal/kldcontracts/rest2eth_test.go
@@ -183,7 +183,8 @@ func newTestREST2Eth(dispatcher *mockREST2EthDispatcher) (*rest2eth, *mockRPC, *
 	abiLoader := &mockABILoader{
 		deployMsg: &deployMsg.DeployContract,
 	}
-	r := newREST2eth(abiLoader, mockRPC, nil, nil, dispatcher, dispatcher)
+	mockProcessor := &mockProcessor{}
+	r := newREST2eth(abiLoader, mockRPC, nil, nil, mockProcessor, dispatcher, dispatcher)
 	router := &httprouter.Router{}
 	r.addRoutes(router)
 
@@ -192,7 +193,8 @@ func newTestREST2Eth(dispatcher *mockREST2EthDispatcher) (*rest2eth, *mockRPC, *
 
 func newTestREST2EthCustomAbiLoader(dispatcher *mockREST2EthDispatcher, abiLoader *mockABILoader) (*rest2eth, *mockRPC, *httprouter.Router) {
 	mockRPC := &mockRPC{}
-	r := newREST2eth(abiLoader, mockRPC, nil, nil, dispatcher, dispatcher)
+	mockProcessor := &mockProcessor{}
+	r := newREST2eth(abiLoader, mockRPC, nil, nil, mockProcessor, dispatcher, dispatcher)
 	router := &httprouter.Router{}
 	r.addRoutes(router)
 
@@ -1184,6 +1186,55 @@ func TestCallMethodSuccess(t *testing.T) {
 	assert.Nil(reply["error"])
 	assert.Equal("123456", reply["i"])
 	assert.Equal("testing", reply["s"])
+}
+
+func TestCallMethodHDWalletSuccess(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	assert := assert.New(t)
+	dir := tempdir()
+	defer cleanup(dir)
+
+	to := "0x567a417717cb6c59ddc1035705f02c0fd1ab1872"
+	dispatcher := &mockREST2EthDispatcher{}
+	from := "HD-u01234abcd-u01234abcd-12345"
+	r, mockRPC, router, res, _ := newTestREST2EthAndMsg(dispatcher, "", to, map[string]interface{}{})
+	r.processor.(*mockProcessor).resolvedFrom = "0x66c5fe653e7a9ebb628a6d40f0452d1e358baee8"
+	req := httptest.NewRequest("GET", "/contracts/"+to+"/get?kld-from="+from, bytes.NewReader([]byte{}))
+	mockRPC.result = "0x000000000000000000000000000000000000000000000000000000000001e2400000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000774657374696e6700000000000000000000000000000000000000000000000000"
+	router.ServeHTTP(res, req)
+
+	assert.Equal(200, res.Result().StatusCode)
+	assert.Equal("eth_call", mockRPC.capturedMethod)
+	assert.Equal("latest", mockRPC.capturedArgs[1])
+	var reply map[string]interface{}
+	err := json.NewDecoder(res.Result().Body).Decode(&reply)
+	assert.NoError(err)
+	log.Infof("Reply: %+v", reply)
+	assert.Nil(reply["error"])
+	assert.Equal("123456", reply["i"])
+	assert.Equal("testing", reply["s"])
+}
+
+func TestCallMethodHDWalletFail(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+	assert := assert.New(t)
+	dir := tempdir()
+	defer cleanup(dir)
+
+	to := "0x567a417717cb6c59ddc1035705f02c0fd1ab1872"
+	dispatcher := &mockREST2EthDispatcher{}
+	from := "HD-u01234abcd-u01234abcd-12345"
+	r, mockRPC, router, res, _ := newTestREST2EthAndMsg(dispatcher, "", to, map[string]interface{}{})
+	r.processor.(*mockProcessor).resolvedFrom = "0x66c5fe653e7a9ebb628a6d40f0452d1e358baee8"
+	r.processor.(*mockProcessor).err = fmt.Errorf("pop")
+	req := httptest.NewRequest("GET", "/contracts/"+to+"/get?kld-from="+from, bytes.NewReader([]byte{}))
+	mockRPC.result = "0x000000000000000000000000000000000000000000000000000000000001e2400000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000774657374696e6700000000000000000000000000000000000000000000000000"
+	router.ServeHTTP(res, req)
+
+	assert.Equal(500, res.Result().StatusCode)
+	var reply map[string]interface{}
+	json.NewDecoder(res.Result().Body).Decode(&reply)
+	assert.Equal("pop", reply["error"])
 }
 
 func TestCallReadOnlyMethodViaPOSTSuccess(t *testing.T) {

--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -164,7 +164,7 @@ func NewSmartContractGateway(conf *SmartContractGatewayConf, txnConf *kldtx.TxnP
 			return nil, klderrors.Errorf(klderrors.RESTGatewayEventManagerInitFailed, err)
 		}
 	}
-	gw.r2e = newREST2eth(gw, rpc, gw.sm, gw.rr, asyncDispatcher, syncDispatcher)
+	gw.r2e = newREST2eth(gw, rpc, gw.sm, gw.rr, processor, asyncDispatcher, syncDispatcher)
 	gw.buildIndex()
 	return gw, nil
 }

--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -1278,7 +1278,7 @@ func (g *smartContractGW) writeHTMLForUI(prefix, id, from string, isGateway, fac
 <html>
 <head>
   <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 characters -->
-  <script src="https://unpkg.com/rapidoc@7.1.0/dist/rapidoc-min.js"></script>
+  <script src="https://unpkg.com/rapidoc@8.1.2/dist/rapidoc-min.js"></script>
 </head>
 <body>
   <rapi-doc 

--- a/internal/kldcontracts/smartcontractgw_test.go
+++ b/internal/kldcontracts/smartcontractgw_test.go
@@ -202,7 +202,7 @@ func TestPreDeployCompileAndPostDeploy(t *testing.T) {
 	assert.Equal("0123456789abcdef0123456789abcdef01234567", info.Address)
 
 	// Check we can get the full ABI swagger back over REST
-	req = httptest.NewRequest("GET", "/abis/message1?swagger", bytes.NewReader([]byte{}))
+	req = httptest.NewRequest("GET", "/abis/message1?swagger&noauth&schemes=http,https,wss", bytes.NewReader([]byte{}))
 	res = httptest.NewRecorder()
 	router.ServeHTTP(res, req)
 	assert.Equal(200, res.Result().StatusCode)
@@ -210,6 +210,8 @@ func TestPreDeployCompileAndPostDeploy(t *testing.T) {
 	err = json.NewDecoder(res.Body).Decode(&swagger)
 	assert.NoError(err)
 	assert.Equal("SimpleEvents", swagger.Info.Title)
+	assert.Equal([]string{"http", "https"}, swagger.Schemes)
+	assert.Nil(swagger.SecurityDefinitions)
 
 	// Check we can get the full ABI back over REST
 	req = httptest.NewRequest("GET", "/abis/message1?abi", bytes.NewReader([]byte{}))

--- a/internal/kldcontracts/syncdispatcher_test.go
+++ b/internal/kldcontracts/syncdispatcher_test.go
@@ -32,6 +32,11 @@ type mockProcessor struct {
 	reply        kldmessages.ReplyWithHeaders
 	unmarshalErr error
 	badUnmarshal bool
+	resolvedFrom string
+}
+
+func (p *mockProcessor) ResolveAddress(from string) (resolvedFrom string, err error) {
+	return p.resolvedFrom, p.err
 }
 
 func (p *mockProcessor) OnMessage(c kldtx.TxnContext) {

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -375,7 +375,7 @@ const (
 	// TransactionSendMsgTypeUnknown we got a JSON message into the core processor (from Kafka, Webhooks etc.) that we don't understand
 	TransactionSendMsgTypeUnknown = "Unknown message type '%s'"
 	// TransactionSendInputTooManyParams more parameters provided than specified on ABI
-	TransactionSendInputTooManyParams = "Supplied %d paramters for ABI that supports %d"
+	TransactionSendInputTooManyParams = "Supplied %d parameters for ABI that supports %d"
 	// TransactionSendInputNotAssignable if we end up in a situation where the generated type cannot be assigned
 	TransactionSendInputNotAssignable = "Method %s param %s: supplied value '%+v' could not be assigned to '%s' field (%s)"
 

--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -731,22 +731,6 @@ func TestNewSendTxnMissingParamTypes(t *testing.T) {
 	assert.EqualError(err, "Param 0: supplied as an object must have 'type' and 'value' fields")
 }
 
-func TestGenMethodABIBadType(t *testing.T) {
-	assert := assert.New(t)
-	_, err := genMethodABI(&kldbind.ABIElementMarshaling{
-		Type: "badness",
-	}, abi.Arguments{})
-	assert.EqualError(err, "Unsupported method type: badness")
-}
-
-func TestGenMethodABIFunctionType(t *testing.T) {
-	assert := assert.New(t)
-	_, err := genMethodABI(&kldbind.ABIElementMarshaling{
-		Type: "function",
-	}, abi.Arguments{})
-	assert.NoError(err)
-}
-
 func TestCallMethod(t *testing.T) {
 	assert := assert.New(t)
 

--- a/internal/kldkafka/kafkabridge_test.go
+++ b/internal/kldkafka/kafkabridge_test.go
@@ -79,6 +79,10 @@ type testKafkaMsgProcessor struct {
 	rpc      kldeth.RPCClient
 }
 
+func (p *testKafkaMsgProcessor) ResolveAddress(from string) (resolvedFrom string, err error) {
+	return from, nil
+}
+
 func (p *testKafkaMsgProcessor) Init(rpc kldeth.RPCClient) {
 	p.rpc = rpc
 }

--- a/internal/kldopenapi/abi2swagger.go
+++ b/internal/kldopenapi/abi2swagger.go
@@ -59,7 +59,7 @@ func (c *ABI2Swagger) Gen4Instance(basePath, name string, abi *abi.ABI, devdocsJ
 	return c.convert(basePath, name, abi, devdocsJSON, true, false, false)
 }
 
-// Gen4Factory generates OpenAPI for a contract factory, with a constructor, and child methods on any addres
+// Gen4Factory generates OpenAPI for a contract factory, with a constructor, and child methods on any address
 func (c *ABI2Swagger) Gen4Factory(basePath, name string, factoryOnly, externalRegistry bool, abi *abi.ABI, devdocsJSON string) *spec.Swagger {
 	return c.convert(basePath, name, abi, devdocsJSON, false, factoryOnly, externalRegistry)
 }

--- a/internal/kldopenapi/abi2swagger.go
+++ b/internal/kldopenapi/abi2swagger.go
@@ -732,6 +732,9 @@ func (c *ABI2Swagger) mapTypeToSchema(s *spec.Schema, t abi.Type) {
 		s.Items.Schema = &spec.Schema{}
 		c.mapTypeToSchema(s.Items.Schema, *t.Elem)
 		break
+	case abi.TupleTy:
+		s.Type = []string{"object"}
+		break
 	}
 
 }

--- a/internal/kldopenapi/abi2swagger_test.go
+++ b/internal/kldopenapi/abi2swagger_test.go
@@ -15,8 +15,10 @@
 package kldopenapi
 
 import (
+	"bufio"
 	"encoding/json"
 	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -96,6 +98,28 @@ func TestABI2SwaggerLotsOfTypesInstance(t *testing.T) {
 	t.Log(string(swaggerBytes))
 
 	expectedJSON, _ := ioutil.ReadFile("../../test/lotsoftypes.swagger.json")
+	assert.Equal(string(expectedJSON), string(swaggerBytes))
+	return
+}
+
+func TestABI2SwaggerV2ABIEncoder(t *testing.T) {
+	assert := assert.New(t)
+
+	c := NewABI2Swagger(&ABI2SwaggerConf{
+		ExternalHost:     "localhost",
+		ExternalRootPath: "/contracts",
+	})
+	f, err := os.Open("../../test/abicoderv2_example.abi.json")
+	assert.NoError(err)
+	abi, err := abi.JSON(bufio.NewReader(f))
+	assert.NoError(err)
+	swagger := c.Gen4Instance("/0x0123456789abcdef0123456789abcdef0123456", "abicoderv2", &abi, lotsOfTypesDevDocs)
+
+	swaggerBytes, err := json.MarshalIndent(&swagger, "", "  ")
+	assert.NoError(err)
+	t.Log(string(swaggerBytes))
+
+	expectedJSON, _ := ioutil.ReadFile("../../test/abicoderv2_example.swagger.json")
 	assert.Equal(string(expectedJSON), string(swaggerBytes))
 	return
 }

--- a/internal/kldrest/webhooksdirect_test.go
+++ b/internal/kldrest/webhooksdirect_test.go
@@ -36,6 +36,7 @@ type mockProcessor struct {
 	capturedCtx *msgContext
 }
 
+func (p *mockProcessor) ResolveAddress(from string) (string, error) { return "", nil }
 func (p *mockProcessor) OnMessage(ctx kldtx.TxnContext) {
 	p.capturedCtx = ctx.(*msgContext)
 }

--- a/internal/kldtx/txnprocessor_test.go
+++ b/internal/kldtx/txnprocessor_test.go
@@ -1191,6 +1191,20 @@ func TestOnDeployContractMessageFailHDWalletFail(t *testing.T) {
 
 }
 
+func TestResolveAddressNonHDWallet(t *testing.T) {
+	assert := assert.New(t)
+
+	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
+		MaxTXWaitTime: 1,
+	}, &kldeth.RPCConf{}).(*txnProcessor)
+	testRPC := goodMessageRPC()
+	txnProcessor.Init(testRPC)
+
+	from, err := txnProcessor.ResolveAddress(testFromAddr)
+	assert.NoError(err)
+	assert.Equal(testFromAddr, from)
+}
+
 func TestResolveAddressHDWalletSuccess(t *testing.T) {
 	assert := assert.New(t)
 

--- a/internal/kldtx/txnprocessor_test.go
+++ b/internal/kldtx/txnprocessor_test.go
@@ -1190,3 +1190,43 @@ func TestOnDeployContractMessageFailHDWalletFail(t *testing.T) {
 	assert.EqualError(testTxnContext.errorReplies[0].err, "HDWallet signing failed")
 
 }
+
+func TestResolveAddressHDWalletSuccess(t *testing.T) {
+	assert := assert.New(t)
+
+	key, _ := ecrypto.GenerateKey()
+	addr := ecrypto.PubkeyToAddress(key.PublicKey)
+	svr := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(200)
+		res.Write([]byte(`
+    {
+      "address": "` + addr.String() + `",
+      "privateKey": "` + hex.EncodeToString(ecrypto.FromECDSA(key)) + `"
+    }`))
+	}))
+	defer svr.Close()
+
+	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
+		MaxTXWaitTime: 1,
+		HDWalletConf: HDWalletConf{
+			URLTemplate: svr.URL,
+		},
+	}, &kldeth.RPCConf{}).(*txnProcessor)
+	testRPC := goodMessageRPC()
+	txnProcessor.Init(testRPC)
+
+	from, err := txnProcessor.ResolveAddress("hd-testinst-testwallet-1234")
+	assert.NoError(err)
+	assert.Equal(addr.String(), from)
+}
+
+func TestResolveAddressHDWalletFail(t *testing.T) {
+	assert := assert.New(t)
+
+	txnProcessor := NewTxnProcessor(&TxnProcessorConf{
+		MaxTXWaitTime: 1,
+	}, &kldeth.RPCConf{}).(*txnProcessor)
+
+	_, err := txnProcessor.ResolveAddress("hd-testinst-testwallet-1234")
+	assert.EqualError(err, "No HD Wallet Configuration")
+}

--- a/test/abicoderv2_example.swagger.json
+++ b/test/abicoderv2_example.swagger.json
@@ -1,0 +1,224 @@
+{
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "swagger": "2.0",
+  "info": {
+    "description": "Challenges the swagger generator to use lots of types",
+    "title": "abicoderv2",
+    "version": "1.0"
+  },
+  "host": "localhost",
+  "basePath": "/contracts/0x0123456789abcdef0123456789abcdef0123456",
+  "paths": {
+    "/inOutType1": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "summary": "inOutType1((string,uint232,(string,string,address,bytes),(string,string,address,bytes)[])) [read only]",
+        "operationId": "inOutType1_get",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "(string,uint232,(string,string,address,bytes),(string,string,address,bytes)[])",
+            "name": "arg1",
+            "in": "query",
+            "required": true
+          },
+          {
+            "$ref": "#/parameters/fromParam"
+          },
+          {
+            "$ref": "#/parameters/valueParam"
+          },
+          {
+            "$ref": "#/parameters/gasParam"
+          },
+          {
+            "$ref": "#/parameters/gaspriceParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful response",
+            "schema": {
+              "$ref": "#/definitions/inOutType1_outputs"
+            }
+          },
+          "default": {
+            "description": "error",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json",
+          "application/x-yaml"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "summary": "inOutType1((string,uint232,(string,string,address,bytes),(string,string,address,bytes)[])) [read only]",
+        "operationId": "inOutType1_post",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/inOutType1_inputs"
+            }
+          },
+          {
+            "$ref": "#/parameters/fromParam"
+          },
+          {
+            "$ref": "#/parameters/valueParam"
+          },
+          {
+            "$ref": "#/parameters/gasParam"
+          },
+          {
+            "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/syncParam"
+          },
+          {
+            "$ref": "#/parameters/callParam"
+          },
+          {
+            "$ref": "#/parameters/privateFromParam"
+          },
+          {
+            "$ref": "#/parameters/privateForParam"
+          },
+          {
+            "$ref": "#/parameters/blocknumberParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful response",
+            "schema": {
+              "$ref": "#/definitions/inOutType1_outputs"
+            }
+          },
+          "default": {
+            "description": "error",
+            "schema": {
+              "$ref": "#/definitions/error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "error": {
+      "properties": {
+        "error": {
+          "description": "Error message",
+          "type": "string"
+        }
+      }
+    },
+    "inOutType1_inputs": {
+      "type": "object",
+      "properties": {
+        "arg1": {
+          "description": "(string,uint232,(string,string,address,bytes),(string,string,address,bytes)[])",
+          "type": "object"
+        }
+      }
+    },
+    "inOutType1_outputs": {
+      "type": "object",
+      "properties": {
+        "out1": {
+          "description": "(string,uint232,(string,string,address,bytes),(string,string,address,bytes)[])",
+          "type": "object"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "blocknumberParam": {
+      "type": "string",
+      "description": "The target block number for eth_call requests. One of 'earliest/latest/pending', a number or a hex string (header: x-kaleido-blocknumber)",
+      "name": "kld-blocknumber",
+      "in": "query"
+    },
+    "callParam": {
+      "type": "boolean",
+      "description": "Perform a read-only call with the same parameters that would be used to invoke, and return result (header: x-kaleido-call)",
+      "name": "kld-call",
+      "in": "query",
+      "allowEmptyValue": true
+    },
+    "fromParam": {
+      "type": "string",
+      "description": "The 'from' address (header: x-kaleido-from)",
+      "name": "kld-from",
+      "in": "query"
+    },
+    "gasParam": {
+      "type": "integer",
+      "description": "Gas to send with the transaction (auto-calculated if not set) (header: x-kaleido-gas)",
+      "name": "kld-gas",
+      "in": "query",
+      "allowEmptyValue": true
+    },
+    "gaspriceParam": {
+      "type": "integer",
+      "description": "Gas Price offered (header: x-kaleido-gasprice)",
+      "name": "kld-gasprice",
+      "in": "query",
+      "allowEmptyValue": true
+    },
+    "privacyGroupIdParam": {
+      "type": "string",
+      "description": "Private transaction group ID (header: x-kaleido-privacyGroupId)",
+      "name": "kld-privacygroupid",
+      "in": "query"
+    },
+    "privateForParam": {
+      "type": "string",
+      "description": "Private transaction recipients (comma separated or multiple params) (header: x-kaleido-privatefor)",
+      "name": "kld-privatefor",
+      "in": "query"
+    },
+    "privateFromParam": {
+      "type": "string",
+      "description": "Private transaction sender (header: x-kaleido-privatefrom)",
+      "name": "kld-privatefrom",
+      "in": "query"
+    },
+    "registerParam": {
+      "type": "string",
+      "description": "Register the installed contract on a friendly path (overwrites existing) (header: x-kaleido-register)",
+      "name": "kld-register",
+      "in": "query"
+    },
+    "syncParam": {
+      "type": "boolean",
+      "default": true,
+      "description": "Block the HTTP request until the tx is mined (does not store the receipt) (header: x-kaleido-sync)",
+      "name": "kld-sync",
+      "in": "query",
+      "allowEmptyValue": true
+    },
+    "valueParam": {
+      "type": "integer",
+      "description": "Ether value to send with the transaction (header: x-kaleido-ethvalue)",
+      "name": "kld-ethvalue",
+      "in": "query",
+      "allowEmptyValue": true
+    }
+  }
+}


### PR DESCRIPTION
Currently calling a `GET` with a `kld-from` set results in:
`Supplied value for 'from' is not a valid hex address`