### PR TITLE
Revert rapidoc to 7.1.0 - issues after upgrade

### DIFF
--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -1278,7 +1278,7 @@ func (g *smartContractGW) writeHTMLForUI(prefix, id, from string, isGateway, fac
 <html>
 <head>
   <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 characters -->
-  <script src="https://unpkg.com/rapidoc@8.1.2/dist/rapidoc-min.js"></script>
+  <script src="https://unpkg.com/rapidoc@7.1.0/dist/rapidoc-min.js"></script>
 </head>
 <body>
   <rapi-doc 


### PR DESCRIPTION
Testing outside of localhost - hit issues such as:

```
rapidoc-min.js:45347 Uncaught DOMException: Failed to execute 'replaceState' on 'History': A history state object with URL '...#post-/' cannot be created in a document with origin '...' and URL '...'.
 ```