### PR TITLE
FIx error parsing events with empty data

### DIFF
--- a/internal/kldeth/txn_test.go
+++ b/internal/kldeth/txn_test.go
@@ -1507,8 +1507,7 @@ func TestProcessRLPBytesValidTypes(t *testing.T) {
 	)
 	assert.NoError(err)
 
-	res, err := ProcessRLPBytes(methodABI.Outputs, rlp)
-	assert.NoError(err)
+	res := ProcessRLPBytes(methodABI.Outputs, rlp)
 	assert.Nil(res["error"])
 
 	assert.Equal("string 1", res["retval1"])
@@ -1567,8 +1566,7 @@ func TestProcessRLPV2ABIEncodedStructs(t *testing.T) {
 
 	rlp, err := abiMethod.Inputs.Pack(typedArgs...)
 	assert.NoError(err)
-	res, err := ProcessRLPBytes(abiMethod.Outputs, rlp)
-	assert.NoError(err)
+	res := ProcessRLPBytes(abiMethod.Outputs, rlp)
 	assert.Nil(res["error"])
 
 	assert.Equal(input1Map, res["out1"])
@@ -1760,8 +1758,8 @@ func TestProcessRLPBytesUnpackFailure(t *testing.T) {
 		},
 	}
 
-	_, err := ProcessRLPBytes(methodABI.Outputs, []byte("this is not the RLP you are looking for"))
-	assert.Regexp("cannot marshal", err.Error())
+	res := ProcessRLPBytes(methodABI.Outputs, []byte("this is not the RLP you are looking for"))
+	assert.Regexp("Failed to unpack values", res["error"])
 }
 
 func TestProcessOutputsTooFew(t *testing.T) {

--- a/internal/kldevents/logprocessor.go
+++ b/internal/kldevents/logprocessor.go
@@ -145,12 +145,14 @@ func (lp *logProcessor) processLogEntry(subInfo string, entry *logEntry, idx int
 	}
 
 	// Retrieve the data args from the RLP and merge the results
-	dataMap, err := kldeth.ProcessRLPBytes(dataArgs, data)
-	if err != nil {
-		return klderrors.Errorf(klderrors.EventStreamsLogDecodeData, subInfo, err)
-	}
-	for k, v := range dataMap {
-		result.Data[k] = v
+	if len(dataArgs) > 0 {
+		dataMap, err := kldeth.ProcessRLPBytes(dataArgs, data)
+		if err != nil {
+			return klderrors.Errorf(klderrors.EventStreamsLogDecodeData, subInfo, err)
+		}
+		for k, v := range dataMap {
+			result.Data[k] = v
+		}
 	}
 
 	// Ok, now we have the full event in a friendly map output. Pass it down to the event processor

--- a/internal/kldevents/logprocessor.go
+++ b/internal/kldevents/logprocessor.go
@@ -146,10 +146,7 @@ func (lp *logProcessor) processLogEntry(subInfo string, entry *logEntry, idx int
 
 	// Retrieve the data args from the RLP and merge the results
 	if len(dataArgs) > 0 {
-		dataMap, err := kldeth.ProcessRLPBytes(dataArgs, data)
-		if err != nil {
-			return klderrors.Errorf(klderrors.EventStreamsLogDecodeData, subInfo, err)
-		}
+		dataMap := kldeth.ProcessRLPBytes(dataArgs, data)
 		for k, v := range dataMap {
 			result.Data[k] = v
 		}

--- a/internal/kldevents/logprocessor_test.go
+++ b/internal/kldevents/logprocessor_test.go
@@ -127,7 +127,8 @@ func TestProcessLogBadRLPData(t *testing.T) {
 		Timestamps: false,
 	}
 	stream := &eventStream{
-		spec: spec,
+		spec:        spec,
+		eventStream: make(chan *eventData, 1),
 	}
 	eventABI := `{
     "name": "event1",
@@ -148,7 +149,9 @@ func TestProcessLogBadRLPData(t *testing.T) {
 		Data: "0x00",
 	}, 0)
 
-	assert.Regexp("Failed to parse RLP data from event", err.Error())
+	assert.NoError(err)
+	ev := <-stream.eventStream
+	assert.Regexp("Failed to unpack values", ev.Data["error"])
 }
 
 func TestProcessLogSampleEvent(t *testing.T) {


### PR DESCRIPTION
When an event only has indexed fields, and no data entries, the following error was observed: 

```
ERROR Failed to process event: sb-c4ad11c7-e1e9-4878-78b6-f23a874fb9fa:CampaignDeployed(string,uint256): Failed to parse RLP data from event: Expected nil in JSON/RPC response. Received: []
```

This has always been an issue, but there has been a change in the latest version from previous versions.

Previously we used to emit the event with the following embedded error:
```
{
  "address": "0x19E75d0d337e17835dc5246f007A1fB17f0bAC89",
  "blockNumber": "475266",
  "transactionIndex": "0x0",
  "transactionHash": "0x23307094299f08a1041de9f1e7ecb67197a5a3c11ce5be775a8147de266b7524",
  "data": {
    "var1": "0x51b201b016025d42c9a0718b75aacc12b1e9c7f16e4bd2c6618aa944ca399156",
    "error": "Expected nil in JSON/RPC response. Received: []",
    "raw": [],
    "rlp": "",
    "supply": "1000"
  },
  "subId": "sb-432cf526-7be6-48e2-5e2f-14d15daee5ee",
  "signature": "ExampleEvent(string,uint256)",
  "logIndex": "0"
}
```