### PR TITLE
Add POST /reset route for subscriptions, with fromBlock

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,8 @@
 coverage:
   status:
+    project:
+      default:
+        threshold: 0.1%
     patch:
       default:
         threshold: 0.1%

--- a/internal/kldcontracts/rest2eth_test.go
+++ b/internal/kldcontracts/rest2eth_test.go
@@ -167,7 +167,10 @@ func (m *mockSubMgr) SubscriptionByID(ctx context.Context, id string) (*kldevent
 	return m.sub, m.err
 }
 func (m *mockSubMgr) DeleteSubscription(ctx context.Context, id string) error { return m.err }
-func (m *mockSubMgr) Close()                                                  {}
+func (m *mockSubMgr) ResetSubscription(ctx context.Context, id, initialBlock string) error {
+	return m.err
+}
+func (m *mockSubMgr) Close() {}
 
 func newTestDeployMsg(addr string) *deployContractWithAddress {
 	compiled, _ := kldeth.CompileContract(simpleEventsSource(), "SimpleEvents", "", "")

--- a/internal/kldevents/subscription_test.go
+++ b/internal/kldevents/subscription_test.go
@@ -270,7 +270,7 @@ func TestUnsubscribe(t *testing.T) {
 			*(res.(*string)) = "true"
 		}),
 	}
-	err := s.unsubscribe(context.Background())
+	err := s.unsubscribe(context.Background(), true)
 	assert.NoError(err)
 	assert.True(s.filterStale)
 }
@@ -278,7 +278,7 @@ func TestUnsubscribe(t *testing.T) {
 func TestUnsubscribeFail(t *testing.T) {
 	assert := assert.New(t)
 	s := &subscription{rpc: kldeth.NewMockRPCClientForSync(fmt.Errorf("pop"), nil)}
-	err := s.unsubscribe(context.Background())
+	err := s.unsubscribe(context.Background(), true)
 	assert.EqualError(err, "pop")
 	assert.True(s.filterStale)
 }


### PR DESCRIPTION
To allow a subscription to be reset back to an earlier block, and replay all those events from the chain

Addresses an enhancement in: https://github.com/kaleido-io/ethconnect/issues/68