### PR TITLE
Couple of event stream fixes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -337,6 +337,7 @@ github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 h1:njlZPzLwU639
 github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3/go.mod h1:hpGUWaI9xL8pRQCTXQgocU38Qw1g0Us7n5PxxTwTCYU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -129,6 +129,8 @@ const (
 	EventStreamsWebSocketInterruptedReceive = "Interrupted waiting for WebSocket acknowledgment"
 	// EventStreamsWebSocketErrorFromClient Error message received from client
 	EventStreamsWebSocketErrorFromClient = "Error received from WebSocket client: %s"
+	// EventStreamsCannotUpdateType cannot change tyep
+	EventStreamsCannotUpdateType = "The type of an event stream cannot be changed"
 
 	// KakfaProducerConfirmMsgUnknown we received a confirmation callback, but we aren't expecting it
 	KakfaProducerConfirmMsgUnknown = "Received confirmation for message not in in-flight map: %s"

--- a/internal/kldevents/eventstream_test.go
+++ b/internal/kldevents/eventstream_test.go
@@ -105,8 +105,7 @@ func newTestStreamForBatching(spec *StreamInfo, db kldkvstore.KVStore, status ..
 		sm.db = db
 	}
 	ctx := context.Background()
-	stream, err := sm.AddStream(ctx, spec)
-	fmt.Printf("err: %s", err)
+	stream, _ := sm.AddStream(ctx, spec)
 	return sm, sm.streams[stream.ID], svr, eventStream
 }
 

--- a/internal/kldevents/eventstream_test.go
+++ b/internal/kldevents/eventstream_test.go
@@ -93,9 +93,11 @@ func newTestStreamForBatching(spec *StreamInfo, db kldkvstore.KVStore, status ..
 		count++
 	})
 	svr := httptest.NewServer(mux)
-	spec.Type = "WEBHOOK"
-	spec.Webhook.URL = svr.URL
-	spec.Webhook.Headers = map[string]string{"x-my-header": "my-value"}
+	if spec.Type == "" {
+		spec.Type = "WEBHOOK"
+		spec.Webhook.URL = svr.URL
+		spec.Webhook.Headers = map[string]string{"x-my-header": "my-value"}
+	}
 	sm := newTestSubscriptionManager()
 	sm.config().WebhooksAllowPrivateIPs = true
 	sm.config().EventPollingIntervalSec = 0
@@ -103,7 +105,8 @@ func newTestStreamForBatching(spec *StreamInfo, db kldkvstore.KVStore, status ..
 		sm.db = db
 	}
 	ctx := context.Background()
-	stream, _ := sm.AddStream(ctx, spec)
+	stream, err := sm.AddStream(ctx, spec)
+	fmt.Printf("err: %s", err)
 	return sm, sm.streams[stream.ID], svr, eventStream
 }
 
@@ -983,6 +986,63 @@ func TestUpdateStream(t *testing.T) {
 	assert.Equal(updatedStream.Webhook.URL, "http://foo.url")
 	assert.Equal(updatedStream.Webhook.Headers["test-h1"], "val1")
 
+	assert.NoError(err)
+}
+
+func TestUpdateStreamSwapType(t *testing.T) {
+	assert := assert.New(t)
+	dir := tempdir(t)
+	defer cleanup(t, dir)
+
+	db, _ := kldkvstore.NewLDBKeyValueStore(dir)
+	sm, stream, svr, eventStream := newTestStreamForBatching(
+		&StreamInfo{
+			ErrorHandling: ErrorHandlingBlock,
+			BatchSize:     5,
+			Webhook:       &webhookActionInfo{},
+		}, db, 200)
+	defer svr.Close()
+	defer close(eventStream)
+	defer stream.stop()
+
+	ctx := context.Background()
+	updateSpec := &StreamInfo{
+		Type: "websocket",
+		WebSocket: &webSocketActionInfo{
+			Topic: "test1",
+		},
+	}
+	_, err := sm.UpdateStream(ctx, stream.spec.ID, updateSpec)
+	assert.EqualError(err, "The type of an event stream cannot be changed")
+}
+
+func TestUpdateWebSocket(t *testing.T) {
+	assert := assert.New(t)
+	dir := tempdir(t)
+	defer cleanup(t, dir)
+
+	db, _ := kldkvstore.NewLDBKeyValueStore(dir)
+	sm, stream, svr, eventStream := newTestStreamForBatching(
+		&StreamInfo{
+			ErrorHandling: ErrorHandlingBlock,
+			BatchSize:     5,
+			Type:          "websocket",
+			WebSocket: &webSocketActionInfo{
+				Topic: "test1",
+			},
+		}, db, 200)
+	defer svr.Close()
+	defer close(eventStream)
+	defer stream.stop()
+
+	ctx := context.Background()
+	updateSpec := &StreamInfo{
+		WebSocket: &webSocketActionInfo{
+			Topic: "test2",
+		},
+	}
+	updatedStream, err := sm.UpdateStream(ctx, stream.spec.ID, updateSpec)
+	assert.Equal("test2", updatedStream.WebSocket.Topic)
 	assert.NoError(err)
 }
 

--- a/internal/kldevents/webhooks.go
+++ b/internal/kldevents/webhooks.go
@@ -42,7 +42,7 @@ func newWebhookAction(es *eventStream, spec *webhookActionInfo) (*webhookAction,
 		return nil, klderrors.Errorf(klderrors.EventStreamsWebhookInvalidURL)
 	}
 	if spec.RequestTimeoutSec == 0 {
-		spec.RequestTimeoutSec = 30000
+		spec.RequestTimeoutSec = 120
 	}
 	return &webhookAction{
 		es:   es,


### PR DESCRIPTION
- Allow editing of the `Topic` for a WebSocket event stream
- Prevent changing the type of an Event Stream
- Bail before editing properties when the user has an error in their config for update
- Set a more sensible default number of seconds for the request timeout - 120seconds rather than 30,000seconds