### PR TITLE
Update websocket client disconnect logic to avoid sending on closed channels

### DIFF
--- a/internal/kldevents/submanager_test.go
+++ b/internal/kldevents/submanager_test.go
@@ -71,13 +71,17 @@ func cleanup(t *testing.T, dir string) {
 	os.RemoveAll(dir)
 }
 
-func newTestSubscriptionManager() *subscriptionMGR {
-	smconf := &SubscriptionManagerConf{}
-	sm := NewSubscriptionManager(smconf, nil, &mockWebSocket{
+func newMockWebSocket() *mockWebSocket {
+	return &mockWebSocket{
 		sender:   make(chan interface{}),
 		receiver: make(chan error),
 		closing:  make(chan struct{}),
-	}).(*subscriptionMGR)
+	}
+}
+
+func newTestSubscriptionManager() *subscriptionMGR {
+	smconf := &SubscriptionManagerConf{}
+	sm := NewSubscriptionManager(smconf, nil, newMockWebSocket()).(*subscriptionMGR)
 	sm.rpc = kldeth.NewMockRPCClientForSync(nil, nil)
 	sm.db = kldkvstore.NewMockKV(nil)
 	sm.config().WebhooksAllowPrivateIPs = true

--- a/internal/kldevents/submanager_test.go
+++ b/internal/kldevents/submanager_test.go
@@ -52,11 +52,12 @@ type mockWebSocket struct {
 	capturedNamespace   string
 	sender              chan interface{}
 	receiver            chan error
+	closing             chan struct{}
 }
 
-func (m *mockWebSocket) GetChannels(namespace string) (chan<- interface{}, <-chan error) {
+func (m *mockWebSocket) GetChannels(namespace string) (chan<- interface{}, <-chan error, <-chan struct{}) {
 	m.capturedNamespace = namespace
-	return m.sender, m.receiver
+	return m.sender, m.receiver, m.closing
 }
 
 func tempdir(t *testing.T) string {
@@ -75,6 +76,7 @@ func newTestSubscriptionManager() *subscriptionMGR {
 	sm := NewSubscriptionManager(smconf, nil, &mockWebSocket{
 		sender:   make(chan interface{}),
 		receiver: make(chan error),
+		closing:  make(chan struct{}),
 	}).(*subscriptionMGR)
 	sm.rpc = kldeth.NewMockRPCClientForSync(nil, nil)
 	sm.db = kldkvstore.NewMockKV(nil)

--- a/internal/kldws/wsserver_test.go
+++ b/internal/kldws/wsserver_test.go
@@ -52,7 +52,7 @@ func TestConnectSendReceiveCycle(t *testing.T) {
 		Type: "listen",
 	})
 
-	s, r := w.GetChannels("")
+	s, r, _ := w.GetChannels("")
 
 	s <- "Hello World"
 
@@ -111,8 +111,8 @@ func TestConnectTopicIsolation(t *testing.T) {
 		Topic: "topic2",
 	})
 
-	s1, r1 := w.GetChannels("topic1")
-	s2, r2 := w.GetChannels("topic2")
+	s1, r1, _ := w.GetChannels("topic1")
+	s2, r2, _ := w.GetChannels("topic2")
 
 	s1 <- "Hello Number 1"
 	s2 <- "Hello Number 2"
@@ -155,12 +155,17 @@ func TestConnectAbandonRequest(t *testing.T) {
 	c.WriteJSON(&webSocketCommandMessage{
 		Type: "listen",
 	})
-	_, r := w.GetChannels("")
+	_, r, closing := w.GetChannels("")
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		<-r
+		select {
+		case <-r:
+			break
+		case <-closing:
+			break
+		}
 		wg.Done()
 	}()
 


### PR DESCRIPTION
It's currently possible to see this issue, because we're using closing of channels to wake up users of the topic interface when a client disconnects - but the goroutine that needs to be woken might be sending on the channel, rather than receiving.
So this PR introduces a third `closing` channel that is simply there to be a notification of closing of connections, and the sender/receiver channels no longer get closed and re-created.

```
[2020-10-09T20:29:55.920Z] ERROR WS/5a141f7e-6db8-4004-4f1f-5385736c8773: Error: read tcp 10.2.98.35:8001->10.2.99.92:33660: use of closed network connection
[2020-10-09T20:29:55.920Z]  INFO WS/5a141f7e-6db8-4004-4f1f-5385736c8773: Disconnected
[2020-10-09T20:29:55.920Z]  INFO WS/19e7844f-1e9b-4717-5f35-9796ecf2d390: Disconnected
panic: send on closed channel
goroutine 972 [running]:
github.com/kaleido-io/ethconnect/internal/kldws.(*webSocketConnection).handleAckOrError(0xc001107130, 0xc00039c140, 0x0, 0x0)
	/kaleido-io/ethconnect/internal/kldws/wsconn.go:144 +0xf8
github.com/kaleido-io/ethconnect/internal/kldws.(*webSocketConnection).listen(0xc001107130)
	/kaleido-io/ethconnect/internal/kldws/wsconn.go:133 +0x4d9
created by github.com/kaleido-io/ethconnect/internal/kldws.newConnection
	/kaleido-io/ethconnect/internal/kldws/wsconn.go:55 +0x10f
```