### PR TITLE
nonce too low error under load when using ethconnect assigned nonces or HD Wallet signing extension

### DIFF
--- a/internal/kldtx/txnprocessor.go
+++ b/internal/kldtx/txnprocessor.go
@@ -305,10 +305,10 @@ func (p *txnProcessor) addInflightWrapper(txnContext TxnContext, msg *kldmessage
 		// (or if gas price is being varied by the submitter the potential of
 		// overwriting a transaction)
 		if inflight.nonce, err = kldeth.GetTransactionCount(txnContext.Context(), p.rpc, &from, "pending"); err != nil {
-			inflightForAddr.highestNonce = inflight.nonce // store the nonce in our inflight txns state
 			p.inflightTxnsLock.Unlock()
 			return
 		}
+    inflightForAddr.highestNonce = inflight.nonce // store the nonce in our inflight txns state
 		fromNode = true
 	}
 


### PR DESCRIPTION
Looking at the below logs, you can see that we get a `nonce too low` error, because we assigned `1` instead of `315` to a message.

```
[2020-12-07T16:57:34.804Z]  INFO In-flight 1010140 added. nonce=314 addr=0xb5a4dbbdce4aabdf302ca4fa443975938dac45b4 before=0 (node=true)
[2020-12-07T16:57:34.833Z]  INFO TX:0x77ec8c36ba9ecf819488bdc2a44fe10ac20fba3e8ab897ed4d6824c19e332f33 Sent OK [0.03s]
[2020-12-07T16:57:34.879Z]  INFO --> GET /instances/0xa14e3bb954ce952ee43a751e061da2d7d370b843/ownerOf?tokenId=1&kld-from=0x150D7c3593EDD3d887B902f9D53A2721Aa2ED272
[2020-12-07T16:57:34.880Z]  INFO Received message 'Content-Type: ' Length: 0
[2020-12-07T16:57:34.880Z]  INFO <-- GET /instances/0xa14e3bb954ce952ee43a751e061da2d7d370b843/ownerOf?tokenId=1&kld-from=0x150D7c3593EDD3d887B902f9D53A2721Aa2ED272 [200]
[2020-12-07T16:57:34.954Z]  INFO --> GET /instances/0xa14e3bb954ce952ee43a751e061da2d7d370b843/ownerOf?tokenId=1&kld-from=0x150D7c3593EDD3d887B902f9D53A2721Aa2ED272
[2020-12-07T16:57:34.955Z]  INFO Received message 'Content-Type: ' Length: 0
[2020-12-07T16:57:34.955Z]  INFO <-- GET /instances/0xa14e3bb954ce952ee43a751e061da2d7d370b843/ownerOf?tokenId=1&kld-from=0x150D7c3593EDD3d887B902f9D53A2721Aa2ED272 [200]
[2020-12-07T16:57:35.221Z]  INFO --> POST /instances/0xa14e3bb954ce952ee43a751e061da2d7d370b843/safeTransferFrom?kld-from=hd-u0tk025b3v-swagju26-1116489003
[2020-12-07T16:57:35.222Z]  INFO Received message 'Content-Type: application/json;charset=utf-8' Length: 115
[2020-12-07T16:57:35.222Z]  INFO Webhook accepted message. MsgID: 832e6f07-e7f1-4edd-5352-cd027d50ae74 Type: SendTransaction
[2020-12-07T16:57:35.227Z]  INFO Webhooks sent message ok: 832e6f07-e7f1-4edd-5352-cd027d50ae74
[2020-12-07T16:57:35.227Z]  INFO <-- POST /instances/0xa14e3bb954ce952ee43a751e061da2d7d370b843/safeTransferFrom?kld-from=hd-u0tk025b3v-swagju26-1116489003 [202]:
{"sent":true,"id":"832e6f07-e7f1-4edd-5352-cd027d50ae74","msg":"u0ezfne884-u0hjv451ns-requests:0:15108"}
[2020-12-07T16:57:35.233Z]  INFO Kafka consumer received message: Partition=0 Offset=15108
[2020-12-07T16:57:35.233Z]  INFO Message now in-flight: MsgContext[: reqOffset=u0ezfne884-u0hjv451ns-requests:0:15108 complete=false received=2020-12-07T16:57:35.233150315Z]
[2020-12-07T16:57:35.233Z]  INFO GET http://localhost:3000/registry/v1/hdwallets/u0tk025b3v/swagju26/1116489003 -->
[2020-12-07T16:57:35.250Z]  INFO GET http://localhost:3000/registry/v1/hdwallets/u0tk025b3v/swagju26/1116489003 <-- [200]
[2020-12-07T16:57:35.250Z]  INFO In-flight 1010141 added. nonce=1 addr=0xb5a4dbbdce4aabdf302ca4fa443975938dac45b4 before=1 (node=false)
[2020-12-07T16:57:35.328Z]  WARN TX: Failed to send: nonce too low [0.08s]
```
