### PR TITLE
Reset to checkpoint after evenstream update

### DIFF
--- a/internal/kldevents/eventstream.go
+++ b/internal/kldevents/eventstream.go
@@ -405,7 +405,7 @@ func (a *eventStream) eventPoller() {
 		case <-a.updateInterrupt:
 			// we were notified by the caller about an ongoing update, no need to continue
 			log.Infof("%s: Notified of an ongoing stream update, exiting event poller", a.spec.ID)
-			a.markAllSubscripitonsStale(ctx)
+			a.markAllSubscriptionsStale(ctx)
 			return
 		case <-time.After(a.pollingInterval): //fall through and continue to the next iteration
 		}

--- a/internal/kldevents/eventstream.go
+++ b/internal/kldevents/eventstream.go
@@ -411,7 +411,7 @@ func (a *eventStream) eventPoller() {
 		}
 	}
 
-	a.markAllSubscripitonsStale(ctx)
+	a.markAllSubscriptionsStale(ctx)
 
 }
 

--- a/internal/kldevents/eventstream.go
+++ b/internal/kldevents/eventstream.go
@@ -325,7 +325,7 @@ func (a *eventStream) isBlocked() bool {
 	return v
 }
 
-func (a *eventStream) markAllSubscripitonsStale(ctx context.Context) {
+func (a *eventStream) markAllSubscriptionsStale(ctx context.Context) {
 	// Mark all subscriptions stale, so they will re-start from the checkpoint if/when we re-run the poller
 	subs := a.sm.subscriptionsForStream(a.spec.ID)
 	for _, sub := range subs {

--- a/internal/kldevents/eventstream.go
+++ b/internal/kldevents/eventstream.go
@@ -325,19 +325,20 @@ func (a *eventStream) isBlocked() bool {
 	return v
 }
 
+func (a *eventStream) markAllSubscripitonsStale(ctx context.Context) {
+	// Mark all subscriptions stale, so they will re-start from the checkpoint if/when we re-run the poller
+	subs := a.sm.subscriptionsForStream(a.spec.ID)
+	for _, sub := range subs {
+		sub.markFilterStale(ctx, true)
+	}
+}
+
 // eventPoller checks every few seconds against the ethereum node for any
 // new events on the subscriptions that are registered for this stream
 func (a *eventStream) eventPoller() {
-	ctx := kldauth.NewSystemAuthContext()
+	defer a.updateWG.Done()
 
-	defer func() {
-		a.updateWG.Done()
-		// Mark all subscriptions stale, so they will re-start from the checkpoint if/when we re-run the poller
-		subs := a.sm.subscriptionsForStream(a.spec.ID)
-		for _, sub := range subs {
-			sub.markFilterStale(ctx, true)
-		}
-	}()
+	ctx := kldauth.NewSystemAuthContext()
 
 	defer func() { a.pollerDone = true }()
 	var checkpoint map[string]*big.Int
@@ -404,10 +405,13 @@ func (a *eventStream) eventPoller() {
 		case <-a.updateInterrupt:
 			// we were notified by the caller about an ongoing update, no need to continue
 			log.Infof("%s: Notified of an ongoing stream update, exiting event poller", a.spec.ID)
+			a.markAllSubscripitonsStale(ctx)
 			return
 		case <-time.After(a.pollingInterval): //fall through and continue to the next iteration
 		}
 	}
+
+	a.markAllSubscripitonsStale(ctx)
 
 }
 

--- a/internal/kldevents/eventstream_test.go
+++ b/internal/kldevents/eventstream_test.go
@@ -777,8 +777,10 @@ func TestCheckpointRecovery(t *testing.T) {
 		if method == "eth_newFilter" {
 			newFilterBlock = args[0].(*ethFilter).FromBlock.ToInt().Uint64()
 			t.Logf("New filter block after checkpoint recovery: %d", newFilterBlock)
-		} else {
+		} else if method == "eth_getFilterChanges" {
 			*(res.(*[]*logEntry)) = []*logEntry{}
+		} else if method == "eth_uninstallFilter" {
+			*(res.(*bool)) = true
 		}
 	})
 
@@ -819,8 +821,10 @@ func TestWithoutCheckpointRecovery(t *testing.T) {
 		} else if method == "eth_newFilter" {
 			initialEndBlock = args[0].(*ethFilter).ToBlock
 			t.Logf("New filter block after recovery with no checkpoint: %s", initialEndBlock)
-		} else {
+		} else if method == "eth_getFilterChanges" {
 			*(res.(*[]*logEntry)) = []*logEntry{}
+		} else if method == "eth_uninstallFilter" {
+			*(res.(*bool)) = true
 		}
 	})
 

--- a/internal/kldevents/subscription.go
+++ b/internal/kldevents/subscription.go
@@ -168,7 +168,7 @@ func (s *subscription) restartFilter(ctx context.Context, since *big.Int) error 
 		return klderrors.Errorf(klderrors.RPCCallReturnedError, "eth_newFilter", err)
 	}
 	s.filteredOnce = false
-	s.filterStale = false
+	s.markFilterStale(ctx, false)
 	log.Infof("%s: created filter from block %s: %s - %+v", s.logName, since.String(), s.filterID.String(), s.info.Filter)
 	return err
 }
@@ -211,7 +211,7 @@ func (s *subscription) processNewEvents(ctx context.Context) error {
 	}
 	if err := s.rpc.CallContext(ctx, &logs, rpcMethod, s.filterID); err != nil {
 		if strings.Contains(err.Error(), "filter not found") {
-			s.filterStale = true
+			s.markFilterStale(ctx, true)
 		}
 		return err
 	}
@@ -232,18 +232,10 @@ func (s *subscription) processNewEvents(ctx context.Context) error {
 }
 
 func (s *subscription) unsubscribe(ctx context.Context, deleting bool) (err error) {
-	var retval string
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 	log.Infof("%s: Unsubscribing existing filter (deleting=%t)", s.logName, deleting)
 	s.deleting = deleting
 	s.resetRequested = false
-	// If unsubscribe is called multiple times, we might not have a filter
-	if !s.filterStale {
-		s.filterStale = true
-		err = s.rpc.CallContext(ctx, &retval, "eth_uninstallFilter", s.filterID)
-		log.Infof("%s: Uninstalled filter (retval=%s)", s.logName, retval)
-	}
+	s.markFilterStale(ctx, true)
 	return err
 }
 
@@ -256,4 +248,19 @@ func (s *subscription) requestReset() {
 
 func (s *subscription) blockHWM() big.Int {
 	return s.lp.getBlockHWM()
+}
+
+func (s *subscription) markFilterStale(ctx context.Context, newFilterStale bool) {
+	log.Debugf("%s: Marking filter stale=%t", s.logName, newFilterStale)
+	// If unsubscribe is called multiple times, we might not have a filter
+	if newFilterStale && !s.filterStale {
+		var retval bool
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		err := s.rpc.CallContext(ctx, &retval, "eth_uninstallFilter", s.filterID)
+		// We treat error as informational here - the filter might already not be valid (if the node restarted)
+		log.Infof("%s: Uninstalled filter. ok=%t (%s)", s.logName, retval, err)
+	}
+	s.filterStale = newFilterStale
+	return
 }

--- a/internal/kldevents/subscription_test.go
+++ b/internal/kldevents/subscription_test.go
@@ -267,19 +267,11 @@ func TestUnsubscribe(t *testing.T) {
 	assert := assert.New(t)
 	s := &subscription{
 		rpc: kldeth.NewMockRPCClientForSync(nil, func(method string, res interface{}, args ...interface{}) {
-			*(res.(*string)) = "true"
+			*(res.(*bool)) = true
 		}),
 	}
 	err := s.unsubscribe(context.Background(), true)
 	assert.NoError(err)
-	assert.True(s.filterStale)
-}
-
-func TestUnsubscribeFail(t *testing.T) {
-	assert := assert.New(t)
-	s := &subscription{rpc: kldeth.NewMockRPCClientForSync(fmt.Errorf("pop"), nil)}
-	err := s.unsubscribe(context.Background(), true)
-	assert.EqualError(err, "pop")
 	assert.True(s.filterStale)
 }
 


### PR DESCRIPTION
If you perform an update of an event stream while a batch is in-flight, then the batch will not be replayed after the update.
That's because the update logic exits all the handlers immediately.
If you stop and restart ethconnect, it will replay the events. Also, if more events arrive these are delivered - if you ack them, then that moves the checkpoint to a HWM beyond the original batch, so those earlier events are missed.

For Webhooks this is a small timing window, but for WebSockets it's large - because a batch stays in-flight while there are no websockets clients connected. So if you do an update while your app is down, and there are messages waiting for it, then those messages get missed.

fyi @gabriel-indik 