### PR TITLE
Adjust highest nonce when there is no gap to fill

### DIFF
--- a/internal/kldeth/send.go
+++ b/internal/kldeth/send.go
@@ -118,7 +118,7 @@ func (tx *Txn) Send(ctx context.Context, rpc RPCClient) (err error) {
 	}
 	if uint64(gas) == uint64(0) {
 		if err = tx.calculateGas(ctx, rpc, txArgs, &gas); err != nil {
-			return
+			return err
 		}
 		// Re-encode the EthTX (for external HD Wallet signing)
 		if to != nil {

--- a/internal/kldtx/txnprocessor.go
+++ b/internal/kldtx/txnprocessor.go
@@ -349,24 +349,25 @@ func (p *txnProcessor) cancelInFlight(inflight *inflightTxn, gapPotential bool) 
 				}
 			}
 		}
+		if higherNonceInflight < 0 {
+			// We did not find a higher nonce in-flight, so there's no gap to fill. However, we need to make sure
+			// that this nonce is re-used by the next incoming transaction for this address, if this is not the first transaction for the address.
+			// If this is the first txn, we would have cleared the key from the map - so there's nothing to update.
+			if gapPotential && p.inflightTxns[inflight.from] != nil {
+				log.Infof("Did not find a Transaction with higher nonce in-flight, setting highest nonce for %s to %d", inflight.from, inflight.nonce-1)
+				p.inflightTxns[inflight.from].highestNonce = inflight.nonce - 1
+			}
+		}
 	}
 	p.inflightTxnsLock.Unlock()
 
 	log.Infof("In-flight %d complete. nonce=%d addr=%s before=%d after=%d", inflight.id, inflight.nonce, inflight.from, before, after)
 
-	if gapPotential {
-		// If we've got a gap potential, we need to submit a gap-fill TX
-		if higherNonceInflight > 0 {
-			log.Warnf("Potential nonce gap. Nonce %d failed to send. Nonce %d in-flight", inflight.nonce, higherNonceInflight)
-			p.submitGapFillTX(inflight)
-		} else {
-			// We did not find a higher nonce in-flight, so there's no gap to fill. However, we need to make sure
-			// that this nonce is re-used by the next incoming transaction for this address
-			log.Infof("Did not find a Transaction with higher nonce in-flight, setting highest nonce for %s to %d", inflight.from, inflight.nonce-1)
-			p.inflightTxns[inflight.from].highestNonce = inflight.nonce - 1
-		}
+	// If we've got a gap potential, we need to submit a gap-fill TX
+	if higherNonceInflight > 0 {
+		log.Warnf("Potential nonce gap. Nonce %d failed to send. Nonce %d in-flight", inflight.nonce, higherNonceInflight)
+		p.submitGapFillTX(inflight)
 	}
-
 }
 
 // submitGapFillTX attempts to send a zero gas, no data, transfer of zero ether transaction


### PR DESCRIPTION
When a transaction cannot be sent due to an error (ex: gas estimation
fails), we check and see if a gap exists (inflight txns with higher
nonce exist), in which case a gap fill transaction is sent. However, in
the case where no gap exists, the `highest nonce` for the `from` address
must be reset to one less than the inflight transaction's nonce so that
the same nonce is re-used for the next incoming transaction.