### PR TITLE
Treat every cancel as a potential gap, until confirmed sent

### DIFF
--- a/internal/kldtx/txnprocessor.go
+++ b/internal/kldtx/txnprocessor.go
@@ -344,11 +344,9 @@ func (p *txnProcessor) cancelInFlight(inflight *inflightTxn, submitted bool) {
 			delete(p.inflightTxns, inflight.from)
 		} else if !submitted {
 			// Check the transactions that are left, to see if any nonce is higher
-			if !inflight.nodeAssignNonce {
-				for _, alreadyInflight := range inflightForAddr.txnsInFlight {
-					if alreadyInflight.nonce > highestNonce {
-						highestNonce = alreadyInflight.nonce
-					}
+			for _, alreadyInflight := range inflightForAddr.txnsInFlight {
+				if alreadyInflight.nonce > highestNonce {
+					highestNonce = alreadyInflight.nonce
 				}
 			}
 
@@ -365,7 +363,7 @@ func (p *txnProcessor) cancelInFlight(inflight *inflightTxn, submitted bool) {
 	log.Infof("In-flight %d complete. nonce=%d addr=%s sub=%t before=%d after=%d highest=%d", inflight.id, inflight.nonce, inflight.from, submitted, before, after, highestNonce)
 
 	// If we've got a gap potential, we need to submit a gap-fill TX
-	if highestNonce > inflight.nonce {
+	if highestNonce > inflight.nonce && !inflight.nodeAssignNonce {
 		log.Warnf("Potential nonce gap. Nonce %d failed to send. Nonce %d in-flight", inflight.nonce, highestNonce)
 		p.submitGapFillTX(inflight)
 	}

--- a/internal/kldtx/txnprocessor.go
+++ b/internal/kldtx/txnprocessor.go
@@ -360,7 +360,7 @@ func (p *txnProcessor) cancelInFlight(inflight *inflightTxn, submitted bool) {
 	}
 	p.inflightTxnsLock.Unlock()
 
-	log.Infof("In-flight %d complete. nonce=%d addr=%s sub=%t before=%d after=%d highest=%d", inflight.id, inflight.nonce, inflight.from, submitted, before, after, highestNonce)
+	log.Infof("In-flight %d complete. nonce=%d addr=%s nan=%t sub=%t before=%d after=%d highest=%d", inflight.id, inflight.nonce, inflight.from, inflight.nodeAssignNonce, submitted, before, after, highestNonce)
 
 	// If we've got a gap potential, we need to submit a gap-fill TX
 	if highestNonce > inflight.nonce && !inflight.nodeAssignNonce {

--- a/internal/kldtx/txnprocessor.go
+++ b/internal/kldtx/txnprocessor.go
@@ -324,48 +324,49 @@ func (p *txnProcessor) addInflightWrapper(txnContext TxnContext, msg *kldmessage
 	return
 }
 
-func (p *txnProcessor) cancelInFlight(inflight *inflightTxn, gapPotential bool) {
+func (p *txnProcessor) cancelInFlight(inflight *inflightTxn, submitted bool) {
 	var before, after int
-	var higherNonceInflight = int64(-1)
+	var highestNonce int64 = -1
 	p.inflightTxnsLock.Lock()
 	if inflightForAddr, exists := p.inflightTxns[inflight.from]; exists {
+		// Remove from the in-flight list
 		before = len(inflightForAddr.txnsInFlight)
 		for idx, alreadyInflight := range inflightForAddr.txnsInFlight {
 			if alreadyInflight.id == inflight.id {
-				p.inflightTxns[inflight.from].txnsInFlight = append(inflightForAddr.txnsInFlight[0:idx], inflightForAddr.txnsInFlight[idx+1:]...)
+				inflightForAddr.txnsInFlight = append(inflightForAddr.txnsInFlight[0:idx], inflightForAddr.txnsInFlight[idx+1:]...)
 				break
 			}
 		}
 		after = len(inflightForAddr.txnsInFlight)
 		// clear the entry for inflight.from when there are no in-flight txns
 		if after == 0 {
+			// Remove the whole in-flight list (no gap potential)
 			delete(p.inflightTxns, inflight.from)
-		}
-		// Check the transactions that are left, to see if any nonce is higher
-		if gapPotential && !inflight.nodeAssignNonce {
-			for _, alreadyInflight := range inflightForAddr.txnsInFlight {
-				if alreadyInflight.nonce > inflight.nonce && alreadyInflight.nonce > higherNonceInflight {
-					higherNonceInflight = alreadyInflight.nonce
+		} else if !submitted {
+			// Check the transactions that are left, to see if any nonce is higher
+			if !inflight.nodeAssignNonce {
+				for _, alreadyInflight := range inflightForAddr.txnsInFlight {
+					if alreadyInflight.nonce > highestNonce {
+						highestNonce = alreadyInflight.nonce
+					}
 				}
 			}
-		}
-		if higherNonceInflight < 0 {
-			// We did not find a higher nonce in-flight, so there's no gap to fill. However, we need to make sure
-			// that this nonce is re-used by the next incoming transaction for this address, if this is not the first transaction for the address.
-			// If this is the first txn, we would have cleared the key from the map - so there's nothing to update.
-			if gapPotential && p.inflightTxns[inflight.from] != nil {
-				log.Infof("Did not find a Transaction with higher nonce in-flight, setting highest nonce for %s to %d", inflight.from, inflight.nonce-1)
-				p.inflightTxns[inflight.from].highestNonce = inflight.nonce - 1
+
+			// If we did not find a higher nonce in-flight, there's no gap to fill.
+			// However, we need to update the highest nonce so this nonce will re-used
+			if highestNonce < inflight.nonce {
+				log.Infof("Cancelled highest nonce in-fight for %s (new highest: %d)", inflight.from, highestNonce)
+				inflightForAddr.highestNonce = highestNonce
 			}
 		}
 	}
 	p.inflightTxnsLock.Unlock()
 
-	log.Infof("In-flight %d complete. nonce=%d addr=%s before=%d after=%d", inflight.id, inflight.nonce, inflight.from, before, after)
+	log.Infof("In-flight %d complete. nonce=%d addr=%s sub=%t before=%d after=%d highest=%d", inflight.id, inflight.nonce, inflight.from, submitted, before, after, highestNonce)
 
 	// If we've got a gap potential, we need to submit a gap-fill TX
-	if higherNonceInflight > 0 {
-		log.Warnf("Potential nonce gap. Nonce %d failed to send. Nonce %d in-flight", inflight.nonce, higherNonceInflight)
+	if highestNonce > inflight.nonce {
+		log.Warnf("Potential nonce gap. Nonce %d failed to send. Nonce %d in-flight", inflight.nonce, highestNonce)
 		p.submitGapFillTX(inflight)
 	}
 }
@@ -496,9 +497,8 @@ func (p *txnProcessor) waitForCompletion(inflight *inflightTxn, initialWaitDelay
 		inflight.txnContext.Reply(&reply)
 	}
 
-	// We've submitted the transaction (even if we didn't get a receipt within our timeout)
-	// it is not a gap potential.
-	p.cancelInFlight(inflight, false)
+	// We've submitted the transaction, even if we didn't get a receipt within our timeout.
+	p.cancelInFlight(inflight, true)
 	inflight.wg.Done()
 }
 
@@ -525,7 +525,7 @@ func (p *txnProcessor) OnDeployContractMessage(txnContext TxnContext, msg *kldme
 
 	tx, err := kldeth.NewContractDeployTxn(msg, inflight.signer)
 	if err != nil {
-		p.cancelInFlight(inflight, false) // No gap potential, we haven't submitted
+		p.cancelInFlight(inflight, false /* not yet submitted */)
 		txnContext.SendErrorReply(400, err)
 		return
 	}
@@ -544,7 +544,7 @@ func (p *txnProcessor) OnSendTransactionMessage(txnContext TxnContext, msg *kldm
 
 	tx, err := kldeth.NewSendTxn(msg, inflight.signer)
 	if err != nil {
-		p.cancelInFlight(inflight, false) // No gap potential, we haven't submitted
+		p.cancelInFlight(inflight, false /* not yet submitted */)
 		txnContext.SendErrorReply(400, err)
 		return
 	}
@@ -574,8 +574,7 @@ func (p *txnProcessor) sendAndTrackMining(txnContext TxnContext, inflight *infli
 		<-p.concurrencySlots // return our slot as soon as send is complete, to let an awaiting send go
 	}
 	if err != nil {
-		// Now we potentially have a gap - if we allocated the nonce, but failed to send
-		p.cancelInFlight(inflight, true)
+		p.cancelInFlight(inflight, false /* not confirmed as submitted, as send failed */)
 		txnContext.SendErrorReplyWithGapFill(400, err, inflight.gapFillTxHash, inflight.gapFillSucceeded)
 		return
 	}


### PR DESCRIPTION
The gap fill logic currently assumes that if we didn't get as far as `eth_send` then there is no potential for `cancelnFlight` to perform gap management in the in-flight pool.

This incorrectly bypassed the fix in https://github.com/kaleido-io/ethconnect/pull/104, if the failure is during transaction preparation before calling `eth_send`. In that case, the action was not a gap-fill, but simply to update the `highestNonce` in the in-flight transaction pool.

I also found the code a little hard to read while investigating the issue, so did a little refactoring to aid readability, and updated the logging in case a further investigation is required.