### PR TITLE
Fix context for getTransactionReceipt in webhooksDirect mode (no Kafka)

### DIFF
--- a/internal/kldrest/webhooksdirect.go
+++ b/internal/kldrest/webhooksdirect.go
@@ -142,7 +142,7 @@ func (w *webhooksDirect) sendWebhookMsg(ctx context.Context, key, msgID string, 
 		return "", 400, klderrors.Errorf(klderrors.WebhooksDirectBadHeaders)
 	}
 	msgContext := &msgContext{
-		ctx:          ctx,
+		ctx:          context.Background(),
 		w:            w,
 		timeReceived: time.Now().UTC(),
 		key:          key,

--- a/internal/kldtx/txnprocessor.go
+++ b/internal/kldtx/txnprocessor.go
@@ -15,6 +15,7 @@
 package kldtx
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -406,7 +407,7 @@ func (p *txnProcessor) waitForCompletion(inflight *inflightTxn, initialWaitDelay
 	var elapsed time.Duration
 	for !isMined && !timedOut {
 
-		if isMined, err = inflight.tx.GetTXReceipt(inflight.txnContext.Context(), p.rpc); err != nil {
+		if isMined, err = inflight.tx.GetTXReceipt(context.Background(), p.rpc); err != nil {
 			// We wait even on connectivity errors, as we've submitted the transaction and
 			// we want to provide a receipt if connectivity resumes within the timeout
 			log.Infof("Failed to get receipt for %s (retries=%d): %s", inflight, retries, err)
@@ -421,7 +422,7 @@ func (p *txnProcessor) waitForCompletion(inflight *inflightTxn, initialWaitDelay
 			delayBeforeRetry := p.inflightTxnDelayer.GetRetryDelay(initialWaitDelay, retries+1)
 			p.inflightTxnsLock.Unlock()
 
-			log.Debugf("Recept not available after %.2fs (retries=%d): %s", elapsed.Seconds(), retries, inflight)
+			log.Debugf("Receipt not available after %.2fs (retries=%d): %s", elapsed.Seconds(), retries, inflight)
 			time.Sleep(delayBeforeRetry)
 			retries++
 		}
@@ -500,7 +501,7 @@ func (p *txnProcessor) waitForCompletion(inflight *inflightTxn, initialWaitDelay
 	inflight.wg.Done()
 }
 
-// addInflight adds a transction to the inflight list, and kick off
+// addInflight adds a transaction to the inflight list, and kick off
 // a goroutine to check for its completion and send the result
 func (p *txnProcessor) trackMining(inflight *inflightTxn, tx *kldeth.Txn) {
 

--- a/internal/kldtx/txnprocessor.go
+++ b/internal/kldtx/txnprocessor.go
@@ -15,7 +15,6 @@
 package kldtx
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -407,7 +406,7 @@ func (p *txnProcessor) waitForCompletion(inflight *inflightTxn, initialWaitDelay
 	var elapsed time.Duration
 	for !isMined && !timedOut {
 
-		if isMined, err = inflight.tx.GetTXReceipt(context.Background(), p.rpc); err != nil {
+		if isMined, err = inflight.tx.GetTXReceipt(inflight.txnContext.Context(), p.rpc); err != nil {
 			// We wait even on connectivity errors, as we've submitted the transaction and
 			// we want to provide a receipt if connectivity resumes within the timeout
 			log.Infof("Failed to get receipt for %s (retries=%d): %s", inflight, retries, err)


### PR DESCRIPTION
Previously, we would pass the current request context to `GetTXReceipt()`. When not using Kafka, this does not work because the context is passed down from the original HTTP request. By the point we get here in the code, we have already responded to the HTTP request, so the context gets canceled. Passing a context that has already been canceled to the RPC package causes an immediate failure (https://pkg.go.dev/github.com/ethereum/go-ethereum@v1.9.23/rpc?utm_source=gopls#Client.CallContext). This change uses a background context so it is not related to the original HTTP request anymore.