### PR TITLE
Fix websocket EventStream with no topic

### DIFF
--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -650,7 +650,6 @@ func (g *smartContractGW) createStream(res http.ResponseWriter, req *http.Reques
 		g.gatewayErrReply(res, req, klderrors.Errorf(klderrors.RESTGatewayEventStreamInvalid, err), 400)
 		return
 	}
-	log.Warn(spec.WebSocket)
 
 	newSpec, err := g.sm.AddStream(req.Context(), &spec)
 	if err != nil {

--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -127,7 +127,7 @@ func (g *smartContractGW) AddRoutes(router *httprouter.Router) {
 	router.POST(kldevents.StreamPathPrefix+"/:id/resume", g.withEventsAuth(g.suspendOrResumeStream))
 }
 
-// NewSmartContractGateway construtor
+// NewSmartContractGateway constructor
 func NewSmartContractGateway(conf *SmartContractGatewayConf, txnConf *kldtx.TxnProcessorConf, rpc kldeth.RPCClient, processor kldtx.TxnProcessor, asyncDispatcher REST2EthAsyncDispatcher, ws kldws.WebSocketChannels) (SmartContractGateway, error) {
 	var baseURL *url.URL
 	var err error
@@ -650,6 +650,7 @@ func (g *smartContractGW) createStream(res http.ResponseWriter, req *http.Reques
 		g.gatewayErrReply(res, req, klderrors.Errorf(klderrors.RESTGatewayEventStreamInvalid, err), 400)
 		return
 	}
+	log.Warn(spec.WebSocket)
 
 	newSpec, err := g.sm.AddStream(req.Context(), &spec)
 	if err != nil {

--- a/internal/kldevents/eventstream.go
+++ b/internal/kldevents/eventstream.go
@@ -107,7 +107,7 @@ type eventStreamAction interface {
 	attemptBatch(batchNumber, attempt uint64, events []*eventData) error
 }
 
-// newEventStream constructor verfies the action is correct, kicks
+// newEventStream constructor verifies the action is correct, kicks
 // off the event batch processor, and blockHWM will be
 // initialied to that supplied (zero on initial, or the
 // value from the checkpoint)

--- a/internal/kldevents/submanager.go
+++ b/internal/kldevents/submanager.go
@@ -96,7 +96,7 @@ func CobraInitSubscriptionManager(cmd *cobra.Command, conf *SubscriptionManagerC
 	cmd.Flags().BoolVarP(&conf.WebhooksAllowPrivateIPs, "events-privips", "J", false, "Allow private IPs in Webhooks")
 }
 
-// NewSubscriptionManager construtor
+// NewSubscriptionManager constructor
 func NewSubscriptionManager(conf *SubscriptionManagerConf, rpc kldeth.RPCClient, wsChannels kldws.WebSocketChannels) SubscriptionManager {
 	sm := &subscriptionMGR{
 		conf:          conf,

--- a/internal/kldevents/websockets.go
+++ b/internal/kldevents/websockets.go
@@ -33,9 +33,13 @@ func newWebSocketAction(es *eventStream, spec *webSocketActionInfo) (*webSocketA
 
 // attemptBatch attempts to deliver a batch over socket IO
 func (w *webSocketAction) attemptBatch(batchNumber, attempt uint64, events []*eventData) error {
-
+	// Implicitly use a topic of "" if no topic has been set
+	topic := ""
+	if w.spec != nil {
+		topic = w.spec.Topic
+	}
 	// Get a blocking channel to send and receive on our chosen namespace
-	sender, receiver, closing := w.es.wsChannels.GetChannels(w.spec.Topic)
+	sender, receiver, closing := w.es.wsChannels.GetChannels(topic)
 
 	// Sent the batch of events
 	select {


### PR DESCRIPTION
When a websocket EventStream is created, if no topic is specified, the `spec` field is a `nil` pointer. This causes `ethconnect` to crash when trying to emit an event. Worse, because the event is persisted to the DB, it tries to send the event again when it starts back up again, causing it to enter an indefinite crash loop.

 This fix changes the existing behavior so that if no topic is specified, the topic is implicitly set to `""`.