### PR TITLE
Add receipts to mongo receipt store with retry

### DIFF
--- a/internal/kldrest/memreceipts.go
+++ b/internal/kldrest/memreceipts.go
@@ -73,7 +73,7 @@ func (m *memoryReceipts) GetReceipt(requestID string) (*map[string]interface{}, 
 	return nil, nil
 }
 
-func (m *memoryReceipts) AddReceipt(receipt *map[string]interface{}) error {
+func (m *memoryReceipts) AddReceipt(requestID string, receipt *map[string]interface{}) error {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 

--- a/internal/kldrest/memreceipts_test.go
+++ b/internal/kldrest/memreceipts_test.go
@@ -43,8 +43,6 @@ func TestMemReceiptsWrapping(t *testing.T) {
 		assert.Equal(val["key"], expectedKey)
 		currItem = currItem.Next()
 	}
-
-	return
 }
 
 func TestMemReceiptsNoIDFilterImpl(t *testing.T) {
@@ -57,6 +55,4 @@ func TestMemReceiptsNoIDFilterImpl(t *testing.T) {
 
 	_, err := r.GetReceipts(0, 0, []string{"test"}, 0, "t", "t")
 	assert.EqualError(err, "Memory receipts do not support filtering")
-
-	return
 }

--- a/internal/kldrest/memreceipts_test.go
+++ b/internal/kldrest/memreceipts_test.go
@@ -32,7 +32,7 @@ func TestMemReceiptsWrapping(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		receipt := make(map[string]interface{})
 		receipt["key"] = fmt.Sprintf("receipt_%d", i)
-		r.AddReceipt(&receipt)
+		r.AddReceipt("key", &receipt)
 	}
 
 	assert.Equal(50, r.receipts.Len())

--- a/internal/kldrest/mongoreceipts.go
+++ b/internal/kldrest/mongoreceipts.go
@@ -74,12 +74,29 @@ func (m *mongoReceipts) connect() (err error) {
 }
 
 // AddReceipt processes an individual reply message, and contains all errors
-func (m *mongoReceipts) AddReceipt(receipt *map[string]interface{}) error {
-	if err := m.collection.Insert(*receipt); err != nil {
-		log.Errorf("Insert failed for object '%.v': %s", *receipt, err)
-		return err
+// To account for any transitory failures writing to mongoDB, it retries adding receipt with a backoff
+func (m *mongoReceipts) AddReceipt(requestID string, receipt *map[string]interface{}) (err error) {
+	retryTimeout := 10 * time.Second
+	backoffFactor := 1.1
+	startTime := time.Now()
+	delay := 500 * time.Millisecond
+	attempt := 0
+	complete := false
+
+	for !complete {
+		if attempt > 0 {
+			log.Infof("%s: Waiting %.2fs before re-attempt:%d mongo write", requestID, delay.Seconds(), attempt)
+			time.Sleep(delay)
+			delay = time.Duration(float64(delay) * backoffFactor)
+		}
+		attempt++
+		err = m.collection.Insert(*receipt)
+		complete = err == nil || time.Since(startTime) > retryTimeout
+		if !complete {
+			log.Errorf("%s: addReceipt attempt: %d failed, err: %s, retryTimeout: %d", requestID, attempt, err, retryTimeout)
+		}
 	}
-	return nil
+	return err
 }
 
 // GetReceipts Returns recent receipts with skip & limit

--- a/internal/kldrest/mongoreceipts_test.go
+++ b/internal/kldrest/mongoreceipts_test.go
@@ -202,7 +202,7 @@ func TestMongoReceiptsAddReceiptFailed(t *testing.T) {
 	mgoMock := &mockMongo{}
 	mgoMock.collection.insertErr = fmt.Errorf("pop")
 	r := &mongoReceipts{
-		conf: &MongoDBReceiptStoreConf{},
+		conf: &MongoDBReceiptStoreConf{RetryTimeoutMS: 2 * 1000},
 		mgo:  mgoMock,
 	}
 

--- a/internal/kldrest/mongoreceipts_test.go
+++ b/internal/kldrest/mongoreceipts_test.go
@@ -115,7 +115,6 @@ func TestNewMongoReceipts(t *testing.T) {
 	conf := &MongoDBReceiptStoreConf{}
 	r := newMongoReceipts(conf)
 	assert.Equal(conf, r.conf)
-	return
 }
 
 func TestMongoReceiptsConnectOK(t *testing.T) {
@@ -139,8 +138,6 @@ func TestMongoReceiptsConnectOK(t *testing.T) {
 	assert.Equal("testcoll", mgoMock.collectionName)
 	assert.Equal(true, mgoMock.collection.collInfo.Capped)
 	assert.Equal(123, mgoMock.collection.collInfo.MaxDocs)
-
-	return
 }
 
 func TestMongoReceiptsConnectConnErr(t *testing.T) {
@@ -154,7 +151,6 @@ func TestMongoReceiptsConnectConnErr(t *testing.T) {
 
 	err := r.connect()
 	assert.EqualError(err, "Unable to connect to MongoDB: pop")
-	return
 }
 
 func TestMongoReceiptsConnectCollErr(t *testing.T) {
@@ -169,7 +165,6 @@ func TestMongoReceiptsConnectCollErr(t *testing.T) {
 
 	err := r.connect()
 	assert.NoError(err)
-	return
 }
 
 func TestMongoReceiptsConnectIdxErr(t *testing.T) {
@@ -184,7 +179,6 @@ func TestMongoReceiptsConnectIdxErr(t *testing.T) {
 
 	err := r.connect()
 	assert.EqualError(err, "Unable to create index: pop")
-	return
 }
 
 func TestMongoReceiptsAddReceiptOK(t *testing.T) {
@@ -235,7 +229,6 @@ func TestMongoReceiptsGetReceiptsOK(t *testing.T) {
 		res2 := make(map[string]interface{})
 		res2["key2"] = "value2"
 		*resArray = append(*resArray, res2)
-		return
 	}
 
 	r.connect()
@@ -245,7 +238,6 @@ func TestMongoReceiptsGetReceiptsOK(t *testing.T) {
 	assert.Equal(2, mgoMock.collection.mockQuery.limit)
 	assert.Equal("value1", (*results)[0]["key1"])
 	assert.Equal("value2", (*results)[1]["key2"])
-	return
 }
 
 func TestMongoReceiptsFilter(t *testing.T) {
@@ -265,7 +257,6 @@ func TestMongoReceiptsFilter(t *testing.T) {
 		res2 := make(map[string]interface{})
 		res2["key2"] = "value2"
 		*resArray = append(*resArray, res2)
-		return
 	}
 
 	r.connect()
@@ -281,7 +272,6 @@ func TestMongoReceiptsFilter(t *testing.T) {
 	assert.Equal(0, mgoMock.collection.mockQuery.limit)
 	assert.Equal("value1", (*results)[0]["key1"])
 	assert.Equal("value2", (*results)[1]["key2"])
-	return
 }
 
 func TestMongoReceiptsGetReceiptsNotFound(t *testing.T) {
@@ -299,7 +289,6 @@ func TestMongoReceiptsGetReceiptsNotFound(t *testing.T) {
 	results, err := r.GetReceipts(5, 2, nil, 0, "", "")
 	assert.NoError(err)
 	assert.Len(*results, 0)
-	return
 }
 
 func TestMongoReceiptsGetReceiptsError(t *testing.T) {
@@ -316,7 +305,6 @@ func TestMongoReceiptsGetReceiptsError(t *testing.T) {
 	r.connect()
 	_, err := r.GetReceipts(5, 2, nil, 0, "", "")
 	assert.EqualError(err, "pop")
-	return
 }
 
 func TestMongoReceiptsGetReceiptOK(t *testing.T) {
@@ -334,7 +322,6 @@ func TestMongoReceiptsGetReceiptOK(t *testing.T) {
 		res1["_id"] = "receipt1"
 		res1["key1"] = "value1"
 		*resMap = res1
-		return
 	}
 
 	r.connect()
@@ -342,7 +329,6 @@ func TestMongoReceiptsGetReceiptOK(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal("receipt1", (*result)["_id"])
 	assert.Equal("value1", (*result)["key1"])
-	return
 }
 
 func TestMongoReceiptsGetReceiptNotFound(t *testing.T) {
@@ -360,7 +346,6 @@ func TestMongoReceiptsGetReceiptNotFound(t *testing.T) {
 	result, err := r.GetReceipt("receipt1")
 	assert.NoError(err)
 	assert.Nil(result)
-	return
 }
 
 func TestMongoReceiptsGetReceiptError(t *testing.T) {
@@ -377,5 +362,4 @@ func TestMongoReceiptsGetReceiptError(t *testing.T) {
 	r.connect()
 	_, err := r.GetReceipt("receipt1")
 	assert.EqualError(err, "pop")
-	return
 }

--- a/internal/kldrest/mongoreceipts_test.go
+++ b/internal/kldrest/mongoreceipts_test.go
@@ -198,9 +198,8 @@ func TestMongoReceiptsAddReceiptOK(t *testing.T) {
 
 	r.connect()
 	receipt := make(map[string]interface{})
-	err := r.AddReceipt(&receipt)
+	err := r.AddReceipt("key", &receipt)
 	assert.NoError(err)
-	return
 }
 
 func TestMongoReceiptsAddReceiptFailed(t *testing.T) {
@@ -215,9 +214,8 @@ func TestMongoReceiptsAddReceiptFailed(t *testing.T) {
 
 	r.connect()
 	receipt := make(map[string]interface{})
-	err := r.AddReceipt(&receipt)
+	err := r.AddReceipt("key", &receipt)
 	assert.EqualError(err, "pop")
-	return
 }
 
 func TestMongoReceiptsGetReceiptsOK(t *testing.T) {

--- a/internal/kldrest/receiptstore.go
+++ b/internal/kldrest/receiptstore.go
@@ -116,7 +116,7 @@ func (r *receiptStore) processReply(msgBytes []byte) {
 	// Insert the receipt into MongoDB - captures errors
 	if requestID != "" && r.persistence != nil {
 		if err := r.persistence.AddReceipt(requestID, &parsedMsg); err != nil {
-			log.Errorf("%s: Failed to insert '%s' into receipt store: %+v", requestID, parsedMsg, err)
+			log.Panicf("%s: Failed to insert '%s' into receipt store: %+v", requestID, parsedMsg, err)
 		} else {
 			log.Infof("%s: Inserted receipt into receipt store", parsedMsg["_id"])
 		}

--- a/internal/kldrest/receiptstore.go
+++ b/internal/kldrest/receiptstore.go
@@ -116,7 +116,7 @@ func (r *receiptStore) processReply(msgBytes []byte) {
 	// Insert the receipt into MongoDB - captures errors
 	if requestID != "" && r.persistence != nil {
 		if err := r.persistence.AddReceipt(requestID, &parsedMsg); err != nil {
-			log.Errorf("%s: Failed to insert '%s' into receipt store: %+v", parsedMsg["_id"], parsedMsg, err)
+			log.Errorf("%s: Failed to insert '%s' into receipt store: %+v", requestID, parsedMsg, err)
 		} else {
 			log.Infof("%s: Inserted receipt into receipt store", parsedMsg["_id"])
 		}

--- a/internal/kldrest/receiptstore.go
+++ b/internal/kldrest/receiptstore.go
@@ -41,7 +41,7 @@ var uuidCharsVerifier, _ = regexp.Compile("^[0-9a-zA-Z-]+$")
 type ReceiptStorePersistence interface {
 	GetReceipts(skip, limit int, ids []string, sinceEpochMS int64, from, to string) (*[]map[string]interface{}, error)
 	GetReceipt(requestID string) (*map[string]interface{}, error)
-	AddReceipt(receipt *map[string]interface{}) error
+	AddReceipt(requestID string, receipt *map[string]interface{}) error
 }
 
 type receiptStore struct {
@@ -115,10 +115,10 @@ func (r *receiptStore) processReply(msgBytes []byte) {
 
 	// Insert the receipt into MongoDB - captures errors
 	if requestID != "" && r.persistence != nil {
-		if err := r.persistence.AddReceipt(&parsedMsg); err != nil {
-			log.Errorf("Failed to insert '%s' into receipt store: %+v", parsedMsg, err)
+		if err := r.persistence.AddReceipt(requestID, &parsedMsg); err != nil {
+			log.Errorf("%s: Failed to insert '%s' into receipt store: %+v", parsedMsg["_id"], parsedMsg, err)
 		} else {
-			log.Infof("Inserted receipt %s into receipt store", parsedMsg["_id"])
+			log.Infof("%s: Inserted receipt into receipt store", parsedMsg["_id"])
 		}
 	}
 }

--- a/internal/kldrest/receiptstore_test.go
+++ b/internal/kldrest/receiptstore_test.go
@@ -42,7 +42,7 @@ func (m *mockReceiptErrs) GetReceipt(requestID string) (*map[string]interface{},
 	return nil, m.err
 }
 
-func (m *mockReceiptErrs) AddReceipt(receipt *map[string]interface{}) error {
+func (m *mockReceiptErrs) AddReceipt(requestID string, receipt *map[string]interface{}) error {
 	return m.err
 }
 
@@ -302,11 +302,11 @@ func TestGetReplyOK(t *testing.T) {
 	fakeReply1 := make(map[string]interface{})
 	fakeReply1["_id"] = "ABCDEFG"
 	fakeReply1["field1"] = "value1"
-	p.AddReceipt(&fakeReply1)
+	p.AddReceipt("_id", &fakeReply1)
 	fakeReply2 := make(map[string]interface{})
 	fakeReply2["_id"] = "BCDEFG"
 	fakeReply2["field1"] = "value2"
-	p.AddReceipt(&fakeReply2)
+	p.AddReceipt("_id", &fakeReply2)
 	status, respJSON, httpErr := testGETObject(ts, "/reply/ABCDEFG")
 	assert.NoError(httpErr)
 	assert.Equal(200, status)
@@ -323,7 +323,7 @@ func TestGetReplyBadData(t *testing.T) {
 	unserializable := make(map[interface{}]interface{})
 	unserializable[true] = "not for json"
 	fakeReply["badness"] = unserializable
-	p.AddReceipt(&fakeReply)
+	p.AddReceipt("_id", &fakeReply)
 	status, respJSON, httpErr := testGETObject(ts, "/reply/ABCDEFG")
 	assert.NoError(httpErr)
 	assert.Equal(500, status)
@@ -383,7 +383,7 @@ func TestGetRepliesDefaultLimit(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		fakeReply := make(map[string]interface{})
 		fakeReply["_id"] = fmt.Sprintf("reply%d", i)
-		p.AddReceipt(&fakeReply)
+		p.AddReceipt("_id", &fakeReply)
 	}
 
 	status, respArr, httpErr := testGETArray(ts, "/replies")
@@ -403,7 +403,7 @@ func TestGetRepliesCustomSkipLimit(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		fakeReply := make(map[string]interface{})
 		fakeReply["_id"] = fmt.Sprintf("reply%d", i)
-		p.AddReceipt(&fakeReply)
+		p.AddReceipt("_id", &fakeReply)
 	}
 
 	status, respArr, httpErr := testGETArray(ts, "/replies?skip=5&limit=20")
@@ -423,7 +423,7 @@ func TestGetRepliesCustomFiltersISO(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		fakeReply := make(map[string]interface{})
 		fakeReply["_id"] = fmt.Sprintf("reply%d", i)
-		p.AddReceipt(&fakeReply)
+		p.AddReceipt("_id", &fakeReply)
 	}
 
 	status, resObj, httpErr := testGETObject(ts, "/replies?from=abc&to=bcd&since=2019-01-01T00:00:00Z")
@@ -440,7 +440,7 @@ func TestGetRepliesCustomFiltersTS(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		fakeReply := make(map[string]interface{})
 		fakeReply["_id"] = fmt.Sprintf("reply%d", i)
-		p.AddReceipt(&fakeReply)
+		p.AddReceipt("_id", &fakeReply)
 	}
 
 	status, resObj, httpErr := testGETObject(ts, "/replies?from=abc&to=bcd&since=1580435959")
@@ -457,7 +457,7 @@ func TestGetRepliesBadSinceTS(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		fakeReply := make(map[string]interface{})
 		fakeReply["_id"] = fmt.Sprintf("reply%d", i)
-		p.AddReceipt(&fakeReply)
+		p.AddReceipt("_id", &fakeReply)
 	}
 
 	status, resObj, httpErr := testGETObject(ts, "/replies?from=abc&to=bcd&since=badness")

--- a/internal/kldrest/receiptstore_test.go
+++ b/internal/kldrest/receiptstore_test.go
@@ -182,7 +182,9 @@ func TestReplyProcessorWithPeristenceErrorSwallows(t *testing.T) {
 	replyMsg.TransactionHash = &txHash
 	replyMsgBytes, _ := json.Marshal(&replyMsg)
 
-	r.processReply(replyMsgBytes)
+	assert.Panics(t, func() {
+		r.processReply(replyMsgBytes)
+	})
 }
 
 func TestReplyProcessorWithErrorReply(t *testing.T) {

--- a/internal/kldrest/restgateway.go
+++ b/internal/kldrest/restgateway.go
@@ -60,6 +60,7 @@ type MongoDBReceiptStoreConf struct {
 	Database         string `json:"database"`
 	Collection       string `json:"collection"`
 	ConnectTimeoutMS int    `json:"connectTimeout"`
+	RetryTimeoutMS   int    `json:"retryTimeout"`
 }
 
 // RESTGatewayConf defines the YAML config structure for a webhooks bridge instance


### PR DESCRIPTION
* To address transient failures writing receipts to mongo, add a retry with backoff.
* I've picked an initial delay of 1 second, a backoff factor of 1.1 and a max retry timeout of 120 seconds.
* also added requestID as an arg to AddReceipt() so that logs can include it as a prefix