### PR TITLE
WebSocket EventStream Broadcast

### DIFF
--- a/internal/kldcontracts/rest2eth_test.go
+++ b/internal/kldcontracts/rest2eth_test.go
@@ -87,6 +87,10 @@ type mockABILoader struct {
 	postDeployError        error
 }
 
+func (m *mockABILoader) SendReply(message interface{}) {
+
+}
+
 func (m *mockABILoader) loadDeployMsgForInstance(addrHexNo0x string) (*kldmessages.DeployContract, *contractInfo, error) {
 	m.capturedAddr = addrHexNo0x
 	return m.deployMsg, m.contractInfo, m.loadABIError

--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -64,6 +64,7 @@ type SmartContractGateway interface {
 	PreDeploy(msg *kldmessages.DeployContract) error
 	PostDeploy(msg *kldmessages.TransactionReceipt) error
 	AddRoutes(router *httprouter.Router)
+	SendReply(message interface{})
 	Shutdown()
 }
 
@@ -125,6 +126,10 @@ func (g *smartContractGW) AddRoutes(router *httprouter.Router) {
 	router.POST(kldevents.SubPathPrefix+"/:id/reset", g.withEventsAuth(g.resetSub))
 	router.POST(kldevents.StreamPathPrefix+"/:id/suspend", g.withEventsAuth(g.suspendOrResumeStream))
 	router.POST(kldevents.StreamPathPrefix+"/:id/resume", g.withEventsAuth(g.suspendOrResumeStream))
+}
+
+func (g *smartContractGW) SendReply(message interface{}) {
+	g.ws.SendReply(message)
 }
 
 // NewSmartContractGateway constructor

--- a/internal/klderrors/errors.go
+++ b/internal/klderrors/errors.go
@@ -131,6 +131,8 @@ const (
 	EventStreamsWebSocketErrorFromClient = "Error received from WebSocket client: %s"
 	// EventStreamsCannotUpdateType cannot change tyep
 	EventStreamsCannotUpdateType = "The type of an event stream cannot be changed"
+	// EventStreamsInvalidDistributionMode unknown distribution mode
+	EventStreamsInvalidDistributionMode = "Invalid distribution mode '%s'. Valid distribution modes are: 'workloadDistribution' and 'broadcast'."
 
 	// KakfaProducerConfirmMsgUnknown we received a confirmation callback, but we aren't expecting it
 	KakfaProducerConfirmMsgUnknown = "Received confirmation for message not in in-flight map: %s"

--- a/internal/kldevents/eventstream.go
+++ b/internal/kldevents/eventstream.go
@@ -33,6 +33,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+type DistributionMode string
+
+const (
+	DistributionModeBroadcast DistributionMode = "broadcast"
+	DistributionModeWLD       DistributionMode = "workloadDistribution"
+)
+
 const (
 	// FromBlockLatest is the special string that means subscribe from the current block
 	FromBlockLatest = "latest"
@@ -77,8 +84,8 @@ type webhookActionInfo struct {
 }
 
 type webSocketActionInfo struct {
-	Topic            string `json:"topic,omitempty"`
-	DistributionMode string `json:"distributionMode,omitempty"`
+	Topic            string           `json:"topic,omitempty"`
+	DistributionMode DistributionMode `json:"distributionMode,omitempty"`
 }
 
 type eventStream struct {
@@ -167,8 +174,8 @@ func newEventStream(sm subscriptionManager, spec *StreamInfo, wsChannels kldws.W
 	case "websocket":
 
 		if spec.WebSocket != nil {
-			distributionMode := strings.ToLower(spec.WebSocket.DistributionMode)
-			if distributionMode != "" && distributionMode != "broadcast" && distributionMode != "workloaddistribution" {
+			distributionMode := spec.WebSocket.DistributionMode
+			if distributionMode != "" && distributionMode != DistributionModeBroadcast && distributionMode != DistributionModeWLD {
 				return nil, klderrors.Errorf(klderrors.EventStreamsInvalidDistributionMode, spec.WebSocket.DistributionMode)
 			}
 			spec.WebSocket.DistributionMode = distributionMode
@@ -255,7 +262,7 @@ func (a *eventStream) update(newSpec *StreamInfo) (spec *StreamInfo, err error) 
 	}
 	if a.spec.Type == "websocket" && newSpec.WebSocket != nil {
 		a.spec.WebSocket.Topic = newSpec.WebSocket.Topic
-		distributionMode := strings.ToLower(newSpec.WebSocket.DistributionMode)
+		distributionMode := newSpec.WebSocket.DistributionMode
 		if distributionMode != "" && distributionMode != "broadcast" && distributionMode != "workloaddistribution" {
 			return nil, klderrors.Errorf(klderrors.EventStreamsInvalidDistributionMode, newSpec.WebSocket.DistributionMode)
 		}

--- a/internal/kldevents/eventstream.go
+++ b/internal/kldevents/eventstream.go
@@ -257,7 +257,7 @@ func (a *eventStream) update(newSpec *StreamInfo) (spec *StreamInfo, err error) 
 		a.spec.WebSocket.Topic = newSpec.WebSocket.Topic
 		distributionMode := strings.ToLower(newSpec.WebSocket.DistributionMode)
 		if distributionMode != "" && distributionMode != "broadcast" && distributionMode != "workloaddistribution" {
-			return nil, klderrors.Errorf(klderrors.EventStreamsInvalidDistributionMode, spec.WebSocket.DistributionMode)
+			return nil, klderrors.Errorf(klderrors.EventStreamsInvalidDistributionMode, newSpec.WebSocket.DistributionMode)
 		}
 		a.spec.WebSocket.DistributionMode = distributionMode
 	}

--- a/internal/kldevents/eventstream.go
+++ b/internal/kldevents/eventstream.go
@@ -165,11 +165,14 @@ func newEventStream(sm subscriptionManager, spec *StreamInfo, wsChannels kldws.W
 			return nil, err
 		}
 	case "websocket":
-		distributionMode := strings.ToLower(spec.WebSocket.DistributionMode)
-		if distributionMode != "" && distributionMode != "broadcast" && distributionMode != "workloaddistribution" {
-			return nil, klderrors.Errorf(klderrors.EventStreamsInvalidDistributionMode, spec.WebSocket.DistributionMode)
+
+		if spec.WebSocket != nil {
+			distributionMode := strings.ToLower(spec.WebSocket.DistributionMode)
+			if distributionMode != "" && distributionMode != "broadcast" && distributionMode != "workloaddistribution" {
+				return nil, klderrors.Errorf(klderrors.EventStreamsInvalidDistributionMode, spec.WebSocket.DistributionMode)
+			}
+			spec.WebSocket.DistributionMode = distributionMode
 		}
-		spec.WebSocket.DistributionMode = distributionMode
 
 		if a.action, err = newWebSocketAction(a, spec.WebSocket); err != nil {
 			return nil, err
@@ -256,7 +259,7 @@ func (a *eventStream) update(newSpec *StreamInfo) (spec *StreamInfo, err error) 
 		if distributionMode != "" && distributionMode != "broadcast" && distributionMode != "workloaddistribution" {
 			return nil, klderrors.Errorf(klderrors.EventStreamsInvalidDistributionMode, spec.WebSocket.DistributionMode)
 		}
-		spec.WebSocket.DistributionMode = distributionMode
+		a.spec.WebSocket.DistributionMode = distributionMode
 	}
 
 	if a.spec.BatchSize != newSpec.BatchSize && newSpec.BatchSize != 0 && newSpec.BatchSize < MaxBatchSize {

--- a/internal/kldevents/eventstream_test.go
+++ b/internal/kldevents/eventstream_test.go
@@ -711,8 +711,10 @@ func TestInterruptWebSocketSend(t *testing.T) {
 
 func TestInterruptWebSocketReceive(t *testing.T) {
 	wsChannels := &mockWebSocket{
-		sender:   make(chan interface{}),
-		receiver: make(chan error),
+		sender:    make(chan interface{}),
+		broadcast: make(chan interface{}),
+		receiver:  make(chan error),
+		closing:   make(chan struct{})
 	}
 	es := &eventStream{
 		wsChannels:      wsChannels,

--- a/internal/kldevents/eventstream_test.go
+++ b/internal/kldevents/eventstream_test.go
@@ -714,7 +714,7 @@ func TestInterruptWebSocketReceive(t *testing.T) {
 		sender:    make(chan interface{}),
 		broadcast: make(chan interface{}),
 		receiver:  make(chan error),
-		closing:   make(chan struct{})
+		closing:   make(chan struct{}),
 	}
 	es := &eventStream{
 		wsChannels:      wsChannels,

--- a/internal/kldevents/submanager_test.go
+++ b/internal/kldevents/submanager_test.go
@@ -51,6 +51,7 @@ type mockWebSocket struct {
 	registeredNamespace string
 	capturedNamespace   string
 	sender              chan interface{}
+	broadcast           chan interface{}
 	receiver            chan error
 	closing             chan struct{}
 }
@@ -73,9 +74,10 @@ func cleanup(t *testing.T, dir string) {
 
 func newMockWebSocket() *mockWebSocket {
 	return &mockWebSocket{
-		sender:   make(chan interface{}),
-		receiver: make(chan error),
-		closing:  make(chan struct{}),
+		sender:    make(chan interface{}),
+		broadcast: make(chan interface{}),
+		receiver:  make(chan error),
+		closing:   make(chan struct{}),
 	}
 }
 

--- a/internal/kldevents/submanager_test.go
+++ b/internal/kldevents/submanager_test.go
@@ -61,6 +61,8 @@ func (m *mockWebSocket) GetChannels(namespace string) (chan<- interface{}, chan<
 	return m.sender, m.broadcast, m.receiver, m.closing
 }
 
+func (m *mockWebSocket) SendReply(message interface{}) {}
+
 func tempdir(t *testing.T) string {
 	dir, _ := ioutil.TempDir("", "kld")
 	t.Logf("tmpdir/create: %s", dir)

--- a/internal/kldevents/submanager_test.go
+++ b/internal/kldevents/submanager_test.go
@@ -56,9 +56,9 @@ type mockWebSocket struct {
 	closing             chan struct{}
 }
 
-func (m *mockWebSocket) GetChannels(namespace string) (chan<- interface{}, <-chan error, <-chan struct{}) {
+func (m *mockWebSocket) GetChannels(namespace string) (chan<- interface{}, chan<- interface{}, <-chan error, <-chan struct{}) {
 	m.capturedNamespace = namespace
-	return m.sender, m.receiver, m.closing
+	return m.sender, m.broadcast, m.receiver, m.closing
 }
 
 func tempdir(t *testing.T) string {

--- a/internal/kldevents/websockets.go
+++ b/internal/kldevents/websockets.go
@@ -48,7 +48,7 @@ func (w *webSocketAction) attemptBatch(batchNumber, attempt uint64, events []*ev
 
 	var channel chan<- interface{}
 	switch w.spec.DistributionMode {
-	case "broadcast":
+	case DistributionModeBroadcast:
 		channel = broadcaster
 	default:
 		channel = sender
@@ -65,7 +65,7 @@ func (w *webSocketAction) attemptBatch(batchNumber, attempt uint64, events []*ev
 	}
 
 	// If we ever add more distribution modes, we may want to change this logic from a simple if statement
-	if w.spec.DistributionMode != "broadcast" {
+	if w.spec.DistributionMode != DistributionModeBroadcast {
 		// Wait for the next ack or exception
 		select {
 		case err = <-receiver:

--- a/internal/kldrest/receiptstore.go
+++ b/internal/kldrest/receiptstore.go
@@ -150,7 +150,7 @@ func (r *receiptStore) writeReceipt(requestID string, receipt map[string]interfa
 		err := r.persistence.AddReceipt(requestID, &receipt)
 		if err == nil {
 			log.Infof("%s: Inserted receipt into receipt store", receipt["_id"])
-			return
+			break
 		}
 
 		log.Errorf("%s: addReceipt attempt: %d failed, err: %s", requestID, attempt, err)
@@ -160,7 +160,7 @@ func (r *receiptStore) writeReceipt(requestID string, receipt map[string]interfa
 		if qErr == nil && existing != nil {
 			log.Warnf("%s: exiting   receipt: %+v", requestID, *existing)
 			log.Warnf("%s: duplicate receipt: %+v", requestID, receipt)
-			return
+			break
 		}
 
 		timeRetrying := time.Since(startTime)
@@ -169,9 +169,8 @@ func (r *receiptStore) writeReceipt(requestID string, receipt map[string]interfa
 			log.Panicf("%s: Failed to insert into receipt store after %.2fs: %s", requestID, timeRetrying.Seconds(), err)
 		}
 	}
-
 	if r.smartContractGW != nil {
-		r.smartContractGW.SendReply(parsedMsg)
+		r.smartContractGW.SendReply(receipt)
 	}
 }
 

--- a/internal/kldrest/receiptstore.go
+++ b/internal/kldrest/receiptstore.go
@@ -121,6 +121,10 @@ func (r *receiptStore) processReply(msgBytes []byte) {
 			log.Infof("%s: Inserted receipt into receipt store", parsedMsg["_id"])
 		}
 	}
+
+	if r.smartContractGW != nil {
+		r.smartContractGW.SendReply(parsedMsg)
+	}
 }
 
 func (r *receiptStore) marshalAndReply(res http.ResponseWriter, req *http.Request, result interface{}) {

--- a/internal/kldrest/webhooks_test.go
+++ b/internal/kldrest/webhooks_test.go
@@ -37,6 +37,7 @@ func (r *popReader) Read(b []byte) (n int, err error) {
 type mockContractGW struct {
 	preDeployErr  error
 	postDeployErr error
+	testChan      chan interface{}
 }
 
 func (m *mockContractGW) PreDeploy(*kldmessages.DeployContract) error { return m.preDeployErr }
@@ -45,7 +46,9 @@ func (m *mockContractGW) PostDeploy(*kldmessages.TransactionReceipt) error { ret
 
 func (m *mockContractGW) AddRoutes(*httprouter.Router) {}
 
-func (m *mockContractGW) SendReply(message interface{}) {}
+func (m *mockContractGW) SendReply(message interface{}) {
+	m.testChan <- message
+}
 
 func (m *mockContractGW) Shutdown() {}
 

--- a/internal/kldrest/webhooks_test.go
+++ b/internal/kldrest/webhooks_test.go
@@ -37,7 +37,8 @@ func (r *popReader) Read(b []byte) (n int, err error) {
 type mockContractGW struct {
 	preDeployErr  error
 	postDeployErr error
-	testChan      chan interface{}
+	testValue     interface{}
+	replyCallback func(message interface{})
 }
 
 func (m *mockContractGW) PreDeploy(*kldmessages.DeployContract) error { return m.preDeployErr }
@@ -47,7 +48,9 @@ func (m *mockContractGW) PostDeploy(*kldmessages.TransactionReceipt) error { ret
 func (m *mockContractGW) AddRoutes(*httprouter.Router) {}
 
 func (m *mockContractGW) SendReply(message interface{}) {
-	m.testChan <- message
+	if m.replyCallback != nil {
+		m.replyCallback(message)
+	}
 }
 
 func (m *mockContractGW) Shutdown() {}

--- a/internal/kldrest/webhooks_test.go
+++ b/internal/kldrest/webhooks_test.go
@@ -45,6 +45,8 @@ func (m *mockContractGW) PostDeploy(*kldmessages.TransactionReceipt) error { ret
 
 func (m *mockContractGW) AddRoutes(*httprouter.Router) {}
 
+func (m *mockContractGW) SendReply(message interface{}) {}
+
 func (m *mockContractGW) Shutdown() {}
 
 type mockHandler struct{}

--- a/internal/kldws/wsserver.go
+++ b/internal/kldws/wsserver.go
@@ -16,6 +16,7 @@ package kldws
 
 import (
 	"net/http"
+	"reflect"
 	"sync"
 	"time"
 
@@ -27,7 +28,7 @@ import (
 // WebSocketChannels is provided to allow us to do a blocking send to a namespace that will complete once a client connects on it
 // We also provide a channel to listen on for closing of the connection, to allow a select to wake on a blocking send
 type WebSocketChannels interface {
-	GetChannels(topic string) (chan<- interface{}, <-chan error, <-chan struct{})
+	GetChannels(topic string) (chan<- interface{}, chan<- interface{}, <-chan error, <-chan struct{})
 }
 
 // WebSocketServer is the full server interface with the init call
@@ -41,28 +42,35 @@ type webSocketServer struct {
 	processingTimeout time.Duration
 	mux               sync.Mutex
 	topics            map[string]*webSocketTopic
+	topicMap          map[string]map[string]*webSocketConnection
+	newTopic          chan bool
 	upgrader          *websocket.Upgrader
 	connections       map[string]*webSocketConnection
 }
 
 type webSocketTopic struct {
-	topic           string
-	senderChannel   chan interface{}
-	receiverChannel chan error
-	closingChannel  chan struct{}
+	topic            string
+	senderChannel    chan interface{}
+	broadcastChannel chan interface{}
+	receiverChannel  chan error
+	closingChannel   chan struct{}
 }
 
 // NewWebSocketServer create a new server with a simplified interface
 func NewWebSocketServer() WebSocketServer {
-	return &webSocketServer{
+	s := &webSocketServer{
 		connections:       make(map[string]*webSocketConnection),
 		topics:            make(map[string]*webSocketTopic),
+		topicMap:          make(map[string]map[string]*webSocketConnection),
+		newTopic:          make(chan bool),
 		processingTimeout: 30 * time.Second,
 		upgrader: &websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
 		},
 	}
+	go s.listenForBroadcasts()
+	return s
 }
 
 func (s *webSocketServer) handler(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
@@ -91,6 +99,9 @@ func (s *webSocketServer) connectionClosed(c *webSocketConnection) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	delete(s.connections, c.id)
+	for _, topic := range c.topics {
+		delete(s.topicMap[topic.topic], c.id)
+	}
 }
 
 func (s *webSocketServer) AddRoutes(r *httprouter.Router) {
@@ -109,17 +120,62 @@ func (s *webSocketServer) getTopic(topic string) *webSocketTopic {
 	t, exists := s.topics[topic]
 	if !exists {
 		t = &webSocketTopic{
-			topic:           topic,
-			senderChannel:   make(chan interface{}),
-			receiverChannel: make(chan error),
-			closingChannel:  make(chan struct{}),
+			topic:            topic,
+			senderChannel:    make(chan interface{}),
+			broadcastChannel: make(chan interface{}),
+			receiverChannel:  make(chan error),
+			closingChannel:   make(chan struct{}),
 		}
 		s.topics[topic] = t
+		s.topicMap[topic] = make(map[string]*webSocketConnection)
+		// Signal to the broadcaster that a new topic has been added
+		s.newTopic <- true
 	}
 	return t
 }
 
-func (s *webSocketServer) GetChannels(topic string) (chan<- interface{}, <-chan error, <-chan struct{}) {
+func (s *webSocketServer) GetChannels(topic string) (chan<- interface{}, chan<- interface{}, <-chan error, <-chan struct{}) {
 	t := s.getTopic(topic)
-	return t.senderChannel, t.receiverChannel, t.closingChannel
+	return t.senderChannel, t.broadcastChannel, t.receiverChannel, t.closingChannel
+}
+
+func (s *webSocketServer) ListenTopic(c *webSocketConnection, topic string) {
+	// Track that this connection is interested in this topic
+	s.topicMap[topic][c.id] = c
+}
+
+func (s *webSocketServer) listenForBroadcasts() {
+	var topics []string
+	buildCases := func() []reflect.SelectCase {
+		topics = make([]string, len(s.topics))
+		cases := make([]reflect.SelectCase, len(s.topics)+1)
+		i := 0
+		for _, t := range s.topics {
+			cases[i] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(t.broadcastChannel)}
+			topics[i] = t.topic
+			i++
+		}
+		cases[i] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(s.newTopic)}
+		return cases
+	}
+	cases := buildCases()
+	for {
+		chosen, value, ok := reflect.Select(cases)
+		if !ok {
+			log.Warn("An error occurred broadcasting the message")
+			return
+		}
+
+		if chosen == len(cases)-1 {
+			// Addition of a new topic
+			cases = buildCases()
+		} else {
+			// Message on one of the existing topics
+			// Gather all connections interested in this topic and send to them
+			topic := topics[chosen]
+			for _, c := range s.topicMap[topic] {
+				c.broadcast <- value.Interface()
+			}
+		}
+	}
 }

--- a/internal/kldws/wsserver_test.go
+++ b/internal/kldws/wsserver_test.go
@@ -52,7 +52,7 @@ func TestConnectSendReceiveCycle(t *testing.T) {
 		Type: "listen",
 	})
 
-	s, r, _ := w.GetChannels("")
+	s, _, r, _ := w.GetChannels("")
 
 	s <- "Hello World"
 
@@ -111,8 +111,8 @@ func TestConnectTopicIsolation(t *testing.T) {
 		Topic: "topic2",
 	})
 
-	s1, r1, _ := w.GetChannels("topic1")
-	s2, r2, _ := w.GetChannels("topic2")
+	s1, _, r1, _ := w.GetChannels("topic1")
+	s2, _, r2, _ := w.GetChannels("topic2")
 
 	s1 <- "Hello Number 1"
 	s2 <- "Hello Number 2"
@@ -155,7 +155,7 @@ func TestConnectAbandonRequest(t *testing.T) {
 	c.WriteJSON(&webSocketCommandMessage{
 		Type: "listen",
 	})
-	_, r, closing := w.GetChannels("")
+	_, _, r, closing := w.GetChannels("")
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)


### PR DESCRIPTION
This PR adds a new behavior for WebSocket EventStreams. The new behavior can be enabled by creating an EventStream with the following request body:

```json
{
    "type": "websocket",
    "websocket": {
         "topic": "foobar",
         "distributionMode": "broadcast"
     }
}
```

The existing behavior is called `workloadDistribution`. It is a pseudo random distribution of Events over all open WebSocket connections listening on that particular topic. Each Event must be ack'd by the WebSocket client before the next event will be sent. If the `websocket` object or the `distributionMode` field is not specified, it will default to using the existing behavior of `workloadDistribution`.

The new behavior is called `broadcast`. It will send the same Event object to every open WebSocket connections listening on that particular topic, at the same time. If there are no open connections listening on that topic at the time of the broadcast, the Event will be dropped. Broadcast events should not be ack'd.

This PR also adds the ability to receive transaction replies (receipts) on a WebSocket broadcast. To begin receiving transaction replies a WebSocket client must send a message to the server indicating that they are interested in receiving replies.

```json
{
    "type": "listenReplies"
}
```

Transaction replies are sent to any and all open WebSocket connections that are listening (by sending the above message). If no WebSockets are currently listening for replies, the reply is not sent on a WebSocket. This will not block transaction operation. If the user is interested in a reply, but didn't have a WebSocket listening at the time that it was broadcast, it is still persisted to MongoDB where it can be retrieved later.