### PR TITLE
Swallow attempts to insert a duplicate receipt

### DIFF
--- a/internal/kldrest/mongoreceipts_test.go
+++ b/internal/kldrest/mongoreceipts_test.go
@@ -202,7 +202,7 @@ func TestMongoReceiptsAddReceiptFailed(t *testing.T) {
 	mgoMock := &mockMongo{}
 	mgoMock.collection.insertErr = fmt.Errorf("pop")
 	r := &mongoReceipts{
-		conf: &MongoDBReceiptStoreConf{RetryTimeoutMS: 2 * 1000},
+		conf: &MongoDBReceiptStoreConf{},
 		mgo:  mgoMock,
 	}
 

--- a/internal/kldrest/receiptstore.go
+++ b/internal/kldrest/receiptstore.go
@@ -17,7 +17,6 @@ package kldrest
 import (
 	"encoding/json"
 	"net/http"
-	"reflect"
 	"regexp"
 	"strconv"
 	"time"
@@ -32,7 +31,9 @@ import (
 )
 
 const (
-	defaultReceiptLimit = 10
+	defaultReceiptLimit      = 10
+	defaultRetryTimeout      = 120 * 1000
+	defaultRetryInitialDelay = 500
 )
 
 var uuidCharsVerifier, _ = regexp.Compile("^[0-9a-zA-Z-]+$")
@@ -51,6 +52,12 @@ type receiptStore struct {
 }
 
 func newReceiptStore(conf *ReceiptStoreConf, persistence ReceiptStorePersistence, smartContractGW kldcontracts.SmartContractGateway) *receiptStore {
+	if conf.RetryTimeoutMS <= 0 {
+		conf.RetryTimeoutMS = defaultRetryTimeout
+	}
+	if conf.RetryInitialDelayMS <= 0 {
+		conf.RetryInitialDelayMS = defaultRetryInitialDelay
+	}
 	return &receiptStore{
 		conf:            conf,
 		persistence:     persistence,
@@ -64,6 +71,15 @@ func (r *receiptStore) addRoutes(router *httprouter.Router) {
 	router.GET("/reply/:id", r.getReply)
 }
 
+func (r *receiptStore) extractHeaders(parsedMsg map[string]interface{}) map[string]interface{} {
+	if iHeaders, exists := parsedMsg["headers"]; exists {
+		if headers, ok := iHeaders.(map[string]interface{}); ok {
+			return headers
+		}
+	}
+	return nil
+}
+
 func (r *receiptStore) processReply(msgBytes []byte) {
 
 	// Parse the reply as JSON
@@ -74,10 +90,8 @@ func (r *receiptStore) processReply(msgBytes []byte) {
 	}
 
 	// Extract the headers
-	var headers map[string]interface{}
-	if iHeaders, exists := parsedMsg["headers"]; exists && reflect.TypeOf(headers).Kind() == reflect.Map {
-		headers = iHeaders.(map[string]interface{})
-	} else {
+	headers := r.extractHeaders(parsedMsg)
+	if headers == nil {
 		log.Errorf("Failed to extract request headers from '%+v'", parsedMsg)
 		return
 	}
@@ -113,12 +127,46 @@ func (r *receiptStore) processReply(msgBytes []byte) {
 	parsedMsg["receivedAt"] = time.Now().UnixNano() / int64(time.Millisecond)
 	parsedMsg["_id"] = requestID
 
-	// Insert the receipt into MongoDB - captures errors
+	// Insert the receipt into persistence - captures errors
 	if requestID != "" && r.persistence != nil {
-		if err := r.persistence.AddReceipt(requestID, &parsedMsg); err != nil {
-			log.Panicf("%s: Failed to insert '%s' into receipt store: %+v", requestID, parsedMsg, err)
-		} else {
-			log.Infof("%s: Inserted receipt into receipt store", parsedMsg["_id"])
+		r.writeReceipt(requestID, parsedMsg)
+	}
+
+}
+
+func (r *receiptStore) writeReceipt(requestID string, receipt map[string]interface{}) {
+	startTime := time.Now()
+	delay := time.Duration(r.conf.RetryInitialDelayMS) * time.Millisecond
+	attempt := 0
+	retryTimeout := time.Duration(r.conf.RetryTimeoutMS) * time.Millisecond
+
+	for {
+		if attempt > 0 {
+			log.Infof("%s: Waiting %.2fs before re-attempt:%d mongo write", requestID, delay.Seconds(), attempt)
+			time.Sleep(delay)
+			delay = time.Duration(float64(delay) * backoffFactor)
+		}
+		attempt++
+		err := r.persistence.AddReceipt(requestID, &receipt)
+		if err == nil {
+			log.Infof("%s: Inserted receipt into receipt store", receipt["_id"])
+			return
+		}
+
+		log.Errorf("%s: addReceipt attempt: %d failed, err: %s", requestID, attempt, err)
+
+		// Check if the reason is that there is a receipt already
+		existing, qErr := r.persistence.GetReceipt(requestID)
+		if qErr == nil && existing != nil {
+			log.Warnf("%s: exiting   receipt: %+v", requestID, *existing)
+			log.Warnf("%s: duplicate receipt: %+v", requestID, receipt)
+			return
+		}
+
+		timeRetrying := time.Since(startTime)
+		if timeRetrying > retryTimeout {
+			log.Infof("%s: receipt: %+v", requestID, receipt)
+			log.Panicf("%s: Failed to insert into receipt store after %.2fs: %s", requestID, timeRetrying.Seconds(), err)
 		}
 	}
 }

--- a/internal/kldrest/restgateway.go
+++ b/internal/kldrest/restgateway.go
@@ -49,8 +49,10 @@ const (
 
 // ReceiptStoreConf is the common configuration for all receipt stores
 type ReceiptStoreConf struct {
-	MaxDocs    int `json:"maxDocs"`
-	QueryLimit int `json:"queryLimit"`
+	MaxDocs             int `json:"maxDocs"`
+	QueryLimit          int `json:"queryLimit"`
+	RetryInitialDelayMS int `json:"retryInitialDelay"`
+	RetryTimeoutMS      int `json:"retryTimeout"`
 }
 
 // MongoDBReceiptStoreConf is the configuration for a MongoDB receipt store
@@ -60,7 +62,6 @@ type MongoDBReceiptStoreConf struct {
 	Database         string `json:"database"`
 	Collection       string `json:"collection"`
 	ConnectTimeoutMS int    `json:"connectTimeout"`
-	RetryTimeoutMS   int    `json:"retryTimeout"`
 }
 
 // RESTGatewayConf defines the YAML config structure for a webhooks bridge instance


### PR DESCRIPTION
Since #113 we will detect errors inserting receipts after processing messages, and retry for a period of time before panicing.

However, in the design of ethconnect there is the possibility of duplicate receipts in an edge case.
Specifically, when we successfully process a message and send a kafka response for that message (which is processed by the receipt store), but then crash before we move our Kafka offset forwards beyond that message.
The message will be replayed from Kafka after the restart, and hence a duplicate receipt can be inserted.

The action we can take at this point is to log and discard the duplicate receipt.