### PR TITLE
Smart contract loading updates and add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.16.4-alpine3.13 AS builder
 WORKDIR /ethconnect
 ADD . .
 RUN apk add make gcc build-base
-RUN make
+RUN go build # TEMP FIX
 
 FROM alpine:latest
 WORKDIR /ethconnect

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.16.4-alpine3.13 AS builder
+WORKDIR /ethconnect
+ADD . .
+RUN apk add make gcc build-base
+RUN make
+
+FROM alpine:latest
+WORKDIR /ethconnect
+COPY --from=builder /ethconnect/ethconnect .
+RUN ln -s /ethconnect/ethconnect /usr/bin/ethconnect
+RUN mkdir abis
+ENTRYPOINT [ "ethconnect", "rest", "-U", "http://127.0.0.1:8080", "-I", "./abis", "-r", "http://127.0.0.1:8545", "-E", "./events" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN make
 FROM alpine:latest
 WORKDIR /ethconnect
 COPY --from=builder /ethconnect/ethconnect .
+COPY --from=builder /ethconnect/start.sh .
 RUN ln -s /ethconnect/ethconnect /usr/bin/ethconnect
 RUN mkdir abis
-ENTRYPOINT [ "ethconnect", "rest", "-U", "http://127.0.0.1:8080", "-I", "./abis", "-r", "http://127.0.0.1:8545", "-E", "./events" ]
+ENTRYPOINT [ "./start.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.16.4-alpine3.13 AS builder
 WORKDIR /ethconnect
 ADD . .
 RUN apk add make gcc build-base
-RUN go build # TEMP FIX
+RUN make
 
 FROM alpine:latest
 WORKDIR /ethconnect

--- a/internal/kldcontracts/smartcontractgw.go
+++ b/internal/kldcontracts/smartcontractgw.go
@@ -1145,14 +1145,14 @@ func (g *smartContractGW) addABI(res http.ResponseWriter, req *http.Request, par
 	abi, err := g.parseABI(req.Form)
 	if err != nil {
 		// TODO: Find appropriate error message
-		g.gatewayErrReply(res, req, klderrors.Errorf(klderrors.RESTGatewayCompileContractCompileFailed, err), 400)
+		g.gatewayErrReply(res, req, klderrors.Errorf(klderrors.RESTGatewayCompileContractInvalidFormData, err), 400)
 		return
 	}
 
 	bytecode, err := g.parseBytecode(req.Form)
 	if err != nil {
 		// TODO: Find appropriate error message
-		g.gatewayErrReply(res, req, klderrors.Errorf(klderrors.RESTGatewayCompileContractCompileFailed, err), 400)
+		g.gatewayErrReply(res, req, klderrors.Errorf(klderrors.RESTGatewayCompileContractInvalidFormData, err), 400)
 		return
 	}
 

--- a/internal/kldcontracts/smartcontractgw_test.go
+++ b/internal/kldcontracts/smartcontractgw_test.go
@@ -2234,8 +2234,6 @@ func TestPublishPreCompiled(t *testing.T) {
 	var contract SolcJson
 	json.Unmarshal(b, &contract)
 
-	// TODO: parse ABI and bytecode out of the file
-
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 	fw, _ := writer.CreateFormField("abi")

--- a/internal/kldcontracts/smartcontractgw_test.go
+++ b/internal/kldcontracts/smartcontractgw_test.go
@@ -2162,7 +2162,6 @@ func TestPublishBadBytecode(t *testing.T) {
 
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
-	writer.Close()
 	fw, _ := writer.CreateFormField("bytecode")
 	io.Copy(fw, bytes.NewReader([]byte("0xNOTHEX")))
 	writer.Close()

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ "$#" -eq 0 ]; then
+    if [ -n "${ETHCONNECT_CONFIGFILE}" ]; then
+        ethconnect server
+    else
+        echo "ETHCONNECT_CONFIGFILE unset, and no commandline parameters. Running with default standalone configuration"
+        ethconnect rest -U http://127.0.0.1:8080 -I ./abis -r http://127.0.0.1:8545 -E ./events
+    fi
+else
+    ethconnect $@
+fi


### PR DESCRIPTION
This PR adds the ability to load an ABI and pre-compiled bytecode at the `/abis` endpoint.

The Dockerfile is also added in this PR.